### PR TITLE
Render content above backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The order settings are saved in is:
 | Advanced | Type | Description |
 |---|:-:|---|
 |`background.useWindowOptionsForAllBackgrounds`|`boolean`|If enabled, all backgrounds will use the options set for the windows background. You still need to add background images separately.|
+|`background.renderContentAboveBackground`|`boolean`|If enabled, content like images, pdfs, and markdown previews will render above the background.|
 |`background.CSS`|`string`|**Advanced Users Only.** Apply raw CSS to VSCode.|
 
 ## ⚠️ Known Issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "code-background",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "code-background",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "license": "GPL-2.0-only",
             "dependencies": {
                 "glob": "8.0.3"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
         "onCommand:background.config",
         "onCommand:background.changelog"
     ],
+    "extensionKind": [
+        "ui"
+    ],
     "contributes": {
         "commands": [
             {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "theme": "dark"
     },
     "publisher": "Katsute",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "private": true,
     "engines": {
         "vscode": "^1.73.0"
@@ -284,9 +284,15 @@
                     "type": "boolean",
                     "default": false
                 },
+                "background.renderContentAboveBackground": {
+                    "markdownDescription": "If enabled, content like images, pdfs, and markdown previews will render above the background.",
+                    "order": 13,
+                    "type": "boolean",
+                    "default": false
+                },
                 "background.CSS": {
                     "markdownDescription": "**Advanced Users Only.** Apply raw CSS to VSCode.",
-                    "order": 13,
+                    "order": 14,
                     "type": "string",
                     "editPresentation": "multilineText",
                     "default": ""

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,8 +207,6 @@ bk_global.appendChild(document.createTextNode(\`
         width: 100%;
         height: 100%;
 
-        z-index: 1000;
-
         position: absolute;
 
         pointer-events: none;
@@ -329,16 +327,6 @@ bk_global.appendChild(document.createTextNode(\`
     div.monaco-list-row[aria-label$=", source: Background (Extension), notification"] ::before {
 
         color: white;
-
-    }
-\`));
-`
-+ // keep webview above background
-`
-bk_global.appendChild(document.createTextNode(\`
-    div[id^="webview-"] {
-
-        z-index: 1001;
 
     }
 \`));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,6 +175,8 @@ const getJS: () => string = () => {
                 for(const f of glob.sync(g).filter(extensions))
                     images[s].push('"' + `data:image/${path.extname(f).substring(1)};base64,${fs.readFileSync(f, "base64")}` + '"');
 
+    const after: boolean = get(`renderContentAboveBackground`);
+
     return `/* ${identifier}-start */` + '\n' + `(() => {` +
 // shared background css
 (`
@@ -184,7 +186,7 @@ bk_global.setAttribute("type", "text/css");
 
 bk_global.appendChild(document.createTextNode(\`
 
-    body[windowTransition="true"] > div[role=application] > div.monaco-grid-view::after,
+    body[windowTransition="true"]${!after ? `::before` : ` > div[role=application] > div.monaco-grid-view::after`},
     body[editorTransition="true"] .split-view-view > .editor-group-container::after,
     body[sidebarTransition="true"] .split-view-view > #workbench\\\\.parts\\\\.sidebar::after,
     body[sidebarTransition="true"] .split-view-view > #workbench\\\\.parts\\\\.auxiliarybar::after,
@@ -194,7 +196,7 @@ bk_global.appendChild(document.createTextNode(\`
 
     }
 
-    body > div[role=application] > div.monaco-grid-view::after,
+    body${!after ? `::before` : ` > div[role=application] > div.monaco-grid-view::after`},
     .split-view-view > .editor-group-container::after,
     .split-view-view > #workbench\\\\.parts\\\\.sidebar::after,
     .split-view-view > #workbench\\\\.parts\\\\.auxiliarybar::after,
@@ -206,6 +208,8 @@ bk_global.appendChild(document.createTextNode(\`
 
         width: 100%;
         height: 100%;
+
+        ${!after ? `z-index: 1000;` : ''}
 
         position: absolute;
 
@@ -237,7 +241,7 @@ const panelTime = ${get("backgroundChangeTime", "panel", true) == 0 ? 0 : Math.m
 `
 if(windowBackgrounds.length > 0){
     bk_global.appendChild(document.createTextNode(\`
-        body > div[role=application] > div.monaco-grid-view::after {
+        body${!after ? `::before` : ` > div[role=application] > div.monaco-grid-view::after`} {
 
             background-position: ${css("backgroundAlignment", "window")};
             background-repeat: ${css("backgroundRepeat", "window")};
@@ -348,7 +352,7 @@ const setWindowBackground = () => {
 
     if(windowBackgrounds.length > 0){
         bk_window_image.appendChild(document.createTextNode(\`
-            body > div[role=application] > div.monaco-grid-view::after {
+            body${!after ? `::before` : ` > div[role=application] > div.monaco-grid-view::after`} {
 
                 background-image: url("\${windowBackgrounds[next(iWindowBackgrounds)]}");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -333,6 +333,16 @@ bk_global.appendChild(document.createTextNode(\`
     }
 \`));
 `
++ // keep webview above background
+`
+bk_global.appendChild(document.createTextNode(\`
+    div[id^="webview-"] {
+
+        z-index: 1001;
+
+    }
+\`));
+`
 + // custom user css
 `
 bk_global.appendChild(document.createTextNode("${cssValue(get("CSS"))}"));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -184,7 +184,7 @@ bk_global.setAttribute("type", "text/css");
 
 bk_global.appendChild(document.createTextNode(\`
 
-    body[windowTransition="true"]::before,
+    body[windowTransition="true"] > div[role=application] > div.monaco-grid-view::after,
     body[editorTransition="true"] .split-view-view > .editor-group-container::after,
     body[sidebarTransition="true"] .split-view-view > #workbench\\\\.parts\\\\.sidebar::after,
     body[sidebarTransition="true"] .split-view-view > #workbench\\\\.parts\\\\.auxiliarybar::after,
@@ -194,7 +194,7 @@ bk_global.appendChild(document.createTextNode(\`
 
     }
 
-    body::before,
+    body > div[role=application] > div.monaco-grid-view::after,
     .split-view-view > .editor-group-container::after,
     .split-view-view > #workbench\\\\.parts\\\\.sidebar::after,
     .split-view-view > #workbench\\\\.parts\\\\.auxiliarybar::after,
@@ -237,7 +237,7 @@ const panelTime = ${get("backgroundChangeTime", "panel", true) == 0 ? 0 : Math.m
 `
 if(windowBackgrounds.length > 0){
     bk_global.appendChild(document.createTextNode(\`
-        body::before {
+        body > div[role=application] > div.monaco-grid-view::after {
 
             background-position: ${css("backgroundAlignment", "window")};
             background-repeat: ${css("backgroundRepeat", "window")};
@@ -348,7 +348,7 @@ const setWindowBackground = () => {
 
     if(windowBackgrounds.length > 0){
         bk_window_image.appendChild(document.createTextNode(\`
-            body::before {
+            body > div[role=application] > div.monaco-grid-view::after {
 
                 background-image: url("\${windowBackgrounds[next(iWindowBackgrounds)]}");
 

--- a/src/vs/package.ts
+++ b/src/vs/package.ts
@@ -36,6 +36,7 @@ export type ConfigKey =
     "backgroundSizeValue" |
     "backgroundChangeTime" |
     "useWindowOptionsForAllBackgrounds" |
+    "renderContentAboveBackground" |
     "CSS";
 
 export type Contributes = {


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Remove z-index so background renders below content
 - Change `body::before` to `body > div[role=application] > div.monaco-grid-view::after`

#### Release Notes

Add new option `background.renderContentAboveBackground` to render content above backgrounds