### PR TITLE
Fix duplicate backgrounds when using horizontal and vertical editor split

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -379,24 +379,24 @@ const setEditorBackground = () => {
 
         shuffle(iEditorBackgrounds);
 
+        let csx = [...Array(len)].map(() => []);
+
+        for(let i = 0; i < len; i++){
+            csx[i].push(\`#workbench\\\\.parts\\\\.editor :not(.split-view-container) .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) > .editor-group-container::after\`);
+
+            for(let j = 0; j < len; j++){
+                csx[(i+j)%len].push(\`#workbench\\\\.parts\\\\.editor .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) .split-view-container > .split-view-view:nth-child(\${len}n+\${j+1}) > .editor-group-container::after\`);
+            };
+        };
+
         for(let i = 0; i < len; i++){
             bk_editor_image.appendChild(document.createTextNode(\`
-                #workbench\\\\.parts\\\\.editor :not(.split-view-container) .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) > .editor-group-container::after {
+                \${csx[i].join(',')} {
 
                     background-image: url("\${editorBackgrounds[iEditorBackgrounds[i]]}");
 
                 }
             \`));
-
-            for(let j = 0; j < len; j++){
-                bk_editor_image.appendChild(document.createTextNode(\`
-                    #workbench\\\\.parts\\\\.editor .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) .split-view-container > .split-view-view:nth-child(\${len}n+\${j+1}) > .editor-group-container::after {
-
-                        background-image: url("\${editorBackgrounds[iEditorBackgrounds[(i+j)%len]]}");
-
-                    }
-                \`));
-            };
         };
     };
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -379,14 +379,21 @@ const setEditorBackground = () => {
 
         shuffle(iEditorBackgrounds);
 
-        for(let i = 1; i <= len; i++){
-            bk_editor_image.appendChild(document.createTextNode(\`
-                .split-view-view:nth-child(\${len}n+\${i}) > .editor-group-container::after {
+        for(let i = 0; i < len; i++){
+            for(let j = 0; j < len; j++){
+                bk_editor_image.appendChild(document.createTextNode(\`
+                    #workbench\\\\.parts\\\\.editor .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) .split-view-container > .split-view-view:nth-child(\${len}n+\${j+1}) > .editor-group-container::after {
 
-                    background-image: url("\${editorBackgrounds[iEditorBackgrounds[i-1]]}");
+                        background-image: url("\${editorBackgrounds[iEditorBackgrounds[(i+j+1)%len]]}");
 
-                }
-            \`));
+                    }
+                    #workbench\\\\.parts\\\\.editor :not(.split-view-container) .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) > .editor-group-container::after {
+
+                        background-image: url("\${editorBackgrounds[iEditorBackgrounds[(i+1)%len]]}");
+
+                    }
+                \`));
+            }
         };
     };
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -383,7 +383,7 @@ const setEditorBackground = () => {
             bk_editor_image.appendChild(document.createTextNode(\`
                 #workbench\\\\.parts\\\\.editor :not(.split-view-container) .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) > .editor-group-container::after {
 
-                    background-image: url("\${editorBackgrounds[iEditorBackgrounds[i%len]]}");
+                    background-image: url("\${editorBackgrounds[iEditorBackgrounds[i]]}");
 
                 }
             \`));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -380,20 +380,23 @@ const setEditorBackground = () => {
         shuffle(iEditorBackgrounds);
 
         for(let i = 0; i < len; i++){
+            bk_editor_image.appendChild(document.createTextNode(\`
+                #workbench\\\\.parts\\\\.editor :not(.split-view-container) .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) > .editor-group-container::after {
+
+                    background-image: url("\${editorBackgrounds[iEditorBackgrounds[i%len]]}");
+
+                }
+            \`));
+
             for(let j = 0; j < len; j++){
                 bk_editor_image.appendChild(document.createTextNode(\`
                     #workbench\\\\.parts\\\\.editor .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) .split-view-container > .split-view-view:nth-child(\${len}n+\${j+1}) > .editor-group-container::after {
 
-                        background-image: url("\${editorBackgrounds[iEditorBackgrounds[(i+j+1)%len]]}");
-
-                    }
-                    #workbench\\\\.parts\\\\.editor :not(.split-view-container) .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) > .editor-group-container::after {
-
-                        background-image: url("\${editorBackgrounds[iEditorBackgrounds[(i+1)%len]]}");
+                        background-image: url("\${editorBackgrounds[iEditorBackgrounds[(i+j)%len]]}");
 
                     }
                 \`));
-            }
+            };
         };
     };
 };


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Closes #68 

_Very complicated css logic:_

**First, handle horizontal splits only:**

`#workbench\\\\.parts\\\\.editor`

`:not(.split-view-container)` _// prevent styling horizontal + vertical combo_

`.split-view-container > .split-view-view:nth-child(\${len}n+\${j+1})`

`> .editor-group-container::after`

**for i = 0; i < len; i++**

|i|0|1|2|3|
|---|---|---|---|---|
|0|0|1|2|3|

For col i, image index is simply `i`

**Then, handle horizontal and vertical splits:**

`#workbench\\\\.parts\\\\.editor`

`.split-view-container > .split-view-view:nth-child(\${len}n+\${i+1})` 

`.split-view-container > .split-view-view:nth-child(\${len}n+\${j+1})`

`> .editor-group-container::after`

**for i, j = 0; i, j < len; i, j++**

|i \ j|0|1|2|3|
|---|---|---|---|---|
|0|0|1|2|3|
|1|1|2|3|0|
|2|2|3|0|1|
|3|3|0|1|2|

For col i, row j, derive image index using `(i+j)%len`