### PR TITLE
Revert duplicate background fix for horizontal and vertical editor splits

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -376,13 +376,6 @@ const setEditorBackground = () => {
                     background-image: url("\${editorBackgrounds[iEditorBackgrounds[i]]}");
                 }
             \`));
-            for(let j = 0; j < len; j++){
-                bk_editor_image.appendChild(document.createTextNode(\`
-                    #workbench\\\\.parts\\\\.editor .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) .split-view-container > .split-view-view:nth-child(\${len}n+\${j+1}) > .editor-group-container::after {
-                        background-image: url("\${editorBackgrounds[iEditorBackgrounds[(i+j)%len]]}");
-                    }
-                \`));
-            };
         };
     };
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,7 +205,7 @@ bk_global.appendChild(document.createTextNode(\`
 
         transition: opacity 1s ease-in-out;
 
-        image-rendering: ${get(`smoothImageRendering`) ? "auto" : "pixelated"};
+        image-rendering: ${get("smoothImageRendering") ? "auto" : "pixelated"};
 
     }
 \`));
@@ -366,28 +366,23 @@ const setEditorBackground = () => {
     };
 
     if(editorBackgrounds.length > 0){
-        const len = editorBackgrounds.length;
+        const len = Math.min(editorBackgrounds.length, 10);
 
         shuffle(iEditorBackgrounds);
 
-        let csx = [...Array(len)].map(() => []);
-
-        for(let i = 0; i < len; i++){
-            csx[i].push(\`#workbench\\\\.parts\\\\.editor :not(.split-view-container) .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) > .editor-group-container::after\`);
-
-            for(let j = 0; j < len; j++){
-                csx[(i+j)%len].push(\`#workbench\\\\.parts\\\\.editor .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) .split-view-container > .split-view-view:nth-child(\${len}n+\${j+1}) > .editor-group-container::after\`);
-            };
-        };
-
         for(let i = 0; i < len; i++){
             bk_editor_image.appendChild(document.createTextNode(\`
-                \${csx[i].join(',')} {
-
+                #workbench\\\\.parts\\\\.editor :not(.split-view-container) .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) > .editor-group-container::after {
                     background-image: url("\${editorBackgrounds[iEditorBackgrounds[i]]}");
-
                 }
             \`));
+            for(let j = 0; j < len; j++){
+                bk_editor_image.appendChild(document.createTextNode(\`
+                    #workbench\\\\.parts\\\\.editor .split-view-container > .split-view-view:nth-child(\${len}n+\${i+1}) .split-view-container > .split-view-view:nth-child(\${len}n+\${j+1}) > .editor-group-container::after {
+                        background-image: url("\${editorBackgrounds[iEditorBackgrounds[(i+j)%len]]}");
+                    }
+                \`));
+            };
         };
     };
 };

--- a/src/vs/package.ts
+++ b/src/vs/package.ts
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-export const pkg = require("../../package.json");
+export const pkg = require("../../package.json"); // do not convert to import
 
 export const cfg = pkg.contributes.configuration.properties;
 


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Reverts #69, causes severe performance issues
 - Impose a hard cap of 10 on editor images

#### Release Notes

This should fix a performance issue caused by 2.3.0 when using editor images.