### PR TITLE
Fix write sometimes not prompting for admin permission

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,9 +122,7 @@ export const write: (content: string) => void = (content: string) => {
     const checksum: string = getChecksum(content);
 
     try{
-        fs.accessSync(js, fs.constants.W_OK);
         fs.writeFileSync(js, content, "utf-8");
-        fs.accessSync(json, fs.constants.W_OK);
         fs.writeFileSync(json, fs.readFileSync(json, "utf-8").replace(replace, checksum).trim(), "utf-8");
         restartVS();
     }catch(err: any){

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,7 +126,7 @@ export const write: (content: string) => void = (content: string) => {
         fs.writeFileSync(json, fs.readFileSync(json, "utf-8").replace(replace, checksum).trim(), "utf-8");
         restartVS();
     }catch(err: any){
-        vscode.window.showWarningMessage("Failed to write changes, run command as administrator?", {detail: "VSCode does not have permission to write to the VSCode folder, run command using administrator permissions?", modal: true}, "Yes").then((value?: string) => {
+        vscode.window.showWarningMessage("Failed to write changes, run command as administrator?", {detail: `VSCode does not have permission to write to the VSCode folder, run command using administrator permissions?\n\n${err.message}`, modal: true}, "Yes").then((value?: string) => {
             if(value === "Yes"){
                 const jst = tmp.fileSync().name;
                 fs.writeFileSync(jst, content, "utf-8");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,15 +110,6 @@ const replace: RegExp = /(?<=^\s*"vs\/workbench\/workbench\.desktop\.main\.js\":
 
 let js: string, json: string;
 
-const canWrite: (path: fs.PathLike) => boolean = (path: fs.PathLike) => {
-    try{
-        fs.accessSync(path, fs.constants.W_OK);
-        return true;
-    }catch(error: any){
-        return false;
-    }
-}
-
 export const installJS: () => void = () => {
     js && json && write(removeJS(fs.readFileSync(js, "utf-8")) + '\n' + getJS());
 }
@@ -130,11 +121,13 @@ export const uninstallJS: () => void = () => {
 export const write: (content: string) => void = (content: string) => {
     const checksum: string = getChecksum(content);
 
-    if(canWrite(js) && canWrite(json)){
+    try{
+        fs.accessSync(js, fs.constants.W_OK);
         fs.writeFileSync(js, content, "utf-8");
+        fs.accessSync(json, fs.constants.W_OK);
         fs.writeFileSync(json, fs.readFileSync(json, "utf-8").replace(replace, checksum).trim(), "utf-8");
         restartVS();
-    }else{
+    }catch(err: any){
         vscode.window.showWarningMessage("Failed to write changes, run command as administrator?", {detail: "VSCode does not have permission to write to the VSCode folder, run command using administrator permissions?", modal: true}, "Yes").then((value?: string) => {
             if(value === "Yes"){
                 const jst = tmp.fileSync().name;


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Fixes #113
 - Fixes issue where node would incorrectly say that write permission was allowed when it wasn't