### PR TITLE
Fix vscode product icon escape on file and delete menus

### DIFF
--- a/src/command/config/file.ts
+++ b/src/command/config/file.ts
@@ -99,7 +99,7 @@ export const menu: (ui: UI) => void = (ui: UI) => {
     const items: CommandQuickPickItem[] = (get(`${ui}Backgrounds`) as string[])
         .filter(unique)
         .map(file => quickPickItem({
-            label: file.replace(/(\${\w+})/g, "\$1"),
+            label: file.replace(/(\$\(\w+\))/g, "\\$1"),
             value: file,
             ui,
             description: `${str.s(glob.count(file), "matching file")}`,
@@ -204,7 +204,7 @@ export const menu: (ui: UI) => void = (ui: UI) => {
                     const items: CommandQuickPickItem[] = (get(`${ui}Backgrounds`) as string[])
                         .filter(unique)
                         .map(file => quickPickItem({
-                            label: file.replace(/(\${\w+})/g, "\$1"),
+                            label: file.replace(/(\$\(\w+\))/g, "\\$1"),
                             value: file,
                             ui: item.ui,
                             description: `${str.s(glob.count(file), "matching file")}`

--- a/src/command/config/file.ts
+++ b/src/command/config/file.ts
@@ -99,7 +99,7 @@ export const menu: (ui: UI) => void = (ui: UI) => {
     const items: CommandQuickPickItem[] = (get(`${ui}Backgrounds`) as string[])
         .filter(unique)
         .map(file => quickPickItem({
-            label: file.replace(/(\${\w+})/g, "\\$1"),
+            label: file.replace(/(\${\w+})/g, "\$1"),
             value: file,
             ui,
             description: `${str.s(glob.count(file), "matching file")}`,
@@ -204,7 +204,7 @@ export const menu: (ui: UI) => void = (ui: UI) => {
                     const items: CommandQuickPickItem[] = (get(`${ui}Backgrounds`) as string[])
                         .filter(unique)
                         .map(file => quickPickItem({
-                            label: file.replace(/(\${\w+})/g, "\\$1"),
+                            label: file.replace(/(\${\w+})/g, "\$1"),
                             value: file,
                             ui: item.ui,
                             description: `${str.s(glob.count(file), "matching file")}`


### PR DESCRIPTION
### Prerequisites
*Issues must meet the following criteria:*

 - [x] No similar pull request exists.
 - [x] Code follows the general code style of this project.
 - [x] No sensitive information is exposed.
 - [x] Relevant comments have been added.

### Code Generators
*The use of GitHub Copilot or ChatGPT is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot or ChatGPT.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Fix incorrect `${...}` escape on file and delete menus (should be `$(...)`)