### PR TITLE
Invert opacity setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The order settings are saved in is:
 |`background.backgroundAlignment`|`enum[4]`|The alignment of the background image.|
 |`background.backgroundAlignmentValue`|`string[4]`|If the background image alignment is set to `Manual`, this is the literal value for the `background-position` css property. Only accepts a [css \<position>](https://developer.mozilla.org/en-US/docs/Web/CSS/position_value).|
 |`background.backgroundBlur`|`string[4]`|Background image blur. Only accepts a [css \<length>](https://developer.mozilla.org/en-US/docs/Web/CSS/length).|
-|`background.backgroundOpacity`|`number[4]`|The UI opacity. 0 is fully visible and 1 is invisible.|
+|`background.backgroundOpacity`|`number[4]`|The UI opacity. 1 is fully visible and 0 is invisible.|
 |`background.backgroundRepeat`|`enum[4]`|The background image repeat.|
 |`background.backgroundSize`|`enum[4]`|The background image size.|
 |`background.backgroundSizeValue`|`string[4]`|If the background image size is set to `Manual`, this is the literal value for the `background-size` css property. Only accepts a [css \<position>](https://developer.mozilla.org/en-US/docs/Web/CSS/position_value).|

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The order settings are saved in is:
 |---|:-:|---|
 |`background.autoInstall`|`boolean`|Automatically installs backgrounds and reloads the window on startup if changes are detected or VSCode updates.<br>This option is disabled when you run the uninstall command.|
 |`background.renderContentAboveBackground`|`boolean`|Render content like images, PDFs, and markdown previews above the background.|
+|`background.useInvertedOpacity`|`boolean`|Use an inverted opacity, so 0 is fully visible and 1 is invisible.|
 |`background.smoothImageRendering`|`boolean`|Use smooth image rendering rather than pixelated rendering when resizing images.|
 |`background.CSS`|`string`|Apply raw CSS to VSCode.|
 

--- a/package.json
+++ b/package.json
@@ -290,15 +290,21 @@
                     "type": "boolean",
                     "default": false
                 },
+                "background.useInvertedOpacity": {
+                    "markdownDescription": "Use an inverted opacity, so 0 is fully visible and 1 is invisible.",
+                    "order": 15,
+                    "type": "boolean",
+                    "default": true
+                },
                 "background.smoothImageRendering": {
                     "markdownDescription": "Use smooth image rendering rather than pixelated rendering when resizing images.",
-                    "order": 15,
+                    "order": 16,
                     "type": "boolean",
                     "default": false
                 },
                 "background.CSS": {
                     "markdownDescription": "Apply raw CSS to VSCode.",
-                    "order": 16,
+                    "order": 17,
                     "type": "string",
                     "editPresentation": "multilineText",
                     "default": ""

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
                     }
                 },
                 "background.backgroundOpacity": {
-                    "markdownDescription": "The background opacity, make sure this number is not to high, otherwise you may not be able to see the UI and revert this change.\n\n`1` is fully visible and `0` is invisible.",
+                    "markdownDescription": "The background opacity, make sure this number is not to high, otherwise you may not be able to see the UI and revert this change.\n\n`1` is fully visible and `0` is invisible. If `#background.useInvertedOpacity#` is true, this logic is inverted.",
                     "type": "array",
                     "order": 7,
                     "default": [
@@ -294,7 +294,7 @@
                     "markdownDescription": "Use an inverted opacity, so 0 is fully visible and 1 is invisible.",
                     "order": 15,
                     "type": "boolean",
-                    "default": true
+                    "default": false
                 },
                 "background.smoothImageRendering": {
                     "markdownDescription": "Use smooth image rendering rather than pixelated rendering when resizing images.",

--- a/package.json
+++ b/package.json
@@ -167,14 +167,14 @@
                     }
                 },
                 "background.backgroundOpacity": {
-                    "markdownDescription": "The UI opacity, make sure this number is not to low, otherwise you may not be able to see the UI and revert this change.\n\n`0` is fully visible and `1` is invisible.",
+                    "markdownDescription": "The background opacity, make sure this number is not to high, otherwise you may not be able to see the UI and revert this change.\n\n`1` is fully visible and `0` is invisible.",
                     "type": "array",
                     "order": 7,
                     "default": [
-                        0.9,
-                        0.9,
-                        0.9,
-                        0.9
+                        0.1,
+                        0.1,
+                        0.1,
+                        0.1
                     ],
                     "minItems": 4,
                     "maxItems": 4,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,9 +137,16 @@ export const activate: (context: ExtensionContext) => any = (context: ExtensionC
 
     if(context.globalState.get("migratedOpacity") !== true){ // if not yet migrated
         if(get("backgroundOpacity", {scope: "global", includeDefault: false})){ // has opacity set
-            update("useInvertedOpacity", true, undefined, true);
+            if(configuration().has("useInvertedOpacity")){
+                update("useInvertedOpacity", true, undefined, true) // update setting
+                    .then(() => context.globalState.update("migratedOpacity", true)) // set migrated (changed)
+                    .then(() => window.showInformationMessage("Background opacity settings have been migrated to the latest version."));
+            }else{
+                commands.executeCommand("workbench.action.reloadWindow"); // outdated manifest, force reload
+            }
+        }else{
+            context.globalState.update("migratedOpacity", true); // set migrated (no change)
         }
-        context.globalState.update("migratedOpacity", true); // set migrated
     }
 
     // install

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import { reload } from "./lib/vscode";
 import { api } from "./extension/api";
 import { install, uninstall } from "./extension/writer";
 import { optionMenu } from "./menu/menu";
-import { configuration } from "./extension/config";
+import { configuration, get, update } from "./extension/config";
 
 //
 
@@ -132,6 +132,17 @@ export const activate: (context: ExtensionContext) => any = (context: ExtensionC
     );
 
     statusbar.show();
+
+    // migrate
+
+    if(context.globalState.get("migratedOpacity") !== true){ // if not yet migrated
+        if(get("backgroundOpacity", {scope: "global", includeDefault: false})){ // has opacity set
+            update("useInvertedOpacity", true, undefined, true);
+        }
+        context.globalState.update("migratedOpacity", true); // set migrated
+    }
+
+    // install
 
     if(configuration().get("autoInstall"))
         install(workbench, product, false);

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -127,7 +127,7 @@ if(windowBackgrounds.length > 0){
             background-repeat: ${getCSS("backgroundRepeat", "window")};
             background-size: ${getCSS("backgroundSize", "window")};
 
-            opacity: ${round(1 - +getCSS("backgroundOpacity", "window"), 2)};
+            opacity: ${round(+getCSS("backgroundOpacity", "window"), 2)};
 
             filter: blur(${getCSS("backgroundBlur", "window")});
 
@@ -145,7 +145,7 @@ if(editorBackgrounds.length > 0){
             background-repeat: ${getCSS("backgroundRepeat", "editor")};
             background-size: ${getCSS("backgroundSize", "editor")};
 
-            opacity: ${round(1 - +getCSS("backgroundOpacity", "editor"), 2)};
+            opacity: ${round(+getCSS("backgroundOpacity", "editor"), 2)};
 
             filter: blur(${getCSS("backgroundBlur", "editor")});
 
@@ -164,7 +164,7 @@ if(sidebarBackgrounds.length > 0){
             background-repeat: ${getCSS("backgroundRepeat", "sidebar")};
             background-size: ${getCSS("backgroundSize", "sidebar")};
 
-            opacity: ${round(1 - +getCSS("backgroundOpacity", "sidebar"), 2)};
+            opacity: ${round(+getCSS("backgroundOpacity", "sidebar"), 2)};
 
             filter: blur(${getCSS("backgroundBlur", "sidebar")});
 
@@ -182,7 +182,7 @@ if(panelBackgrounds.length > 0){
             background-repeat: ${getCSS("backgroundRepeat", "panel")};
             background-size: ${getCSS("backgroundSize", "panel")};
 
-            opacity: ${round(1 - +getCSS("backgroundOpacity", "panel"), 2)};
+            opacity: ${round(+getCSS("backgroundOpacity", "panel"), 2)};
 
             filter: blur(${getCSS("backgroundBlur", "panel")});
 

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -127,7 +127,7 @@ if(windowBackgrounds.length > 0){
             background-repeat: ${getCSS("backgroundRepeat", "window")};
             background-size: ${getCSS("backgroundSize", "window")};
 
-            opacity: ${round(+getCSS("backgroundOpacity", "window"), 2)};
+            opacity: ${round(get("useInvertedOpacity") ? 1 - +getCSS("backgroundOpacity", "window") : +getCSS("backgroundOpacity", "window"), 2)};
 
             filter: blur(${getCSS("backgroundBlur", "window")});
 
@@ -145,7 +145,7 @@ if(editorBackgrounds.length > 0){
             background-repeat: ${getCSS("backgroundRepeat", "editor")};
             background-size: ${getCSS("backgroundSize", "editor")};
 
-            opacity: ${round(+getCSS("backgroundOpacity", "editor"), 2)};
+            opacity: ${round(get("useInvertedOpacity") ? 1 - +getCSS("backgroundOpacity", "editor") : +getCSS("backgroundOpacity", "editor"), 2)};
 
             filter: blur(${getCSS("backgroundBlur", "editor")});
 
@@ -164,7 +164,7 @@ if(sidebarBackgrounds.length > 0){
             background-repeat: ${getCSS("backgroundRepeat", "sidebar")};
             background-size: ${getCSS("backgroundSize", "sidebar")};
 
-            opacity: ${round(+getCSS("backgroundOpacity", "sidebar"), 2)};
+            opacity: ${round(get("useInvertedOpacity") ? 1 - +getCSS("backgroundOpacity", "sidebar") : +getCSS("backgroundOpacity", "sidebar"), 2)};
 
             filter: blur(${getCSS("backgroundBlur", "sidebar")});
 
@@ -182,7 +182,7 @@ if(panelBackgrounds.length > 0){
             background-repeat: ${getCSS("backgroundRepeat", "panel")};
             background-size: ${getCSS("backgroundSize", "panel")};
 
-            opacity: ${round(+getCSS("backgroundOpacity", "panel"), 2)};
+            opacity: ${round(get("useInvertedOpacity") ? 1 - +getCSS("backgroundOpacity", "panel") : +getCSS("backgroundOpacity", "panel"), 2)};
 
             filter: blur(${getCSS("backgroundBlur", "panel")});
 

--- a/src/extension/package.ts
+++ b/src/extension/package.ts
@@ -33,6 +33,7 @@ export type ConfigurationKey =
     "backgroundChangeTime" |
     "autoInstall" |
     "renderContentAboveBackground" |
+    "useInvertedOpacity" |
     "smoothImageRendering" |
     "CSS";
 

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -114,7 +114,7 @@ const moreMenu: (selected?: number) => void = (selected?: number) => {
             label: "Setting Scope",
             description: `[${get("settingScope")}]`,
             detail: "Where to save settings; workspace requires Auto Install to update background on switch",
-            handle: () => update("settingScope", get("settingScope") === "Global" ? "Workspace" : "Global").then(() => moreMenu(3))
+            handle: () => update("settingScope", get("settingScope") === "Global" ? "Workspace" : "Global").then(() => moreMenu(i++))
         }),
         separator(),
         quickPickItem({

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -83,24 +83,32 @@ const moreMenu: (selected?: number) => void = (selected?: number) => {
     const descriptionBool: (key: ConfigurationKey) => string = (key: ConfigurationKey) => `[$(${get(key) ? "check" : "close"})]`;
     const handleBool: (key: ConfigurationKey, index: number) => (item: CommandQuickPickItem) => void = (key: ConfigurationKey, index: number) => () => update(key, !get(key)).then(() => moreMenu(index));
 
+    let i = 0;
+
     showQuickPick([
         quickPickItem({
             label: "Auto Install",
             description: descriptionBool("autoInstall"),
             detail: "Automatically install background on startup or when VSCode updates",
-            handle: handleBool("autoInstall", 0)
+            handle: handleBool("autoInstall", i++)
         }),
         quickPickItem({
             label: "Render Content Above Background",
-            description: `[$(${get("renderContentAboveBackground") ? "check" : "close"})]`,
+            description: descriptionBool("renderContentAboveBackground"),
             detail: "Render content like images, PDFs, and markdown previews above the background",
-            handle: handleBool("renderContentAboveBackground", 1)
+            handle: handleBool("renderContentAboveBackground", i++)
+        }),
+        quickPickItem({
+            label: "Use Inverted Opacity",
+            description: descriptionBool("useInvertedOpacity"),
+            detail: "Use an inverted opacity, so 0 is fully visible and 1 is invisible",
+            handle: handleBool("useInvertedOpacity", i++)
         }),
         quickPickItem({
             label: "Smooth Image Rendering",
-            description: `[$(${get("smoothImageRendering") ? "check" : "close"})]`,
+            description: descriptionBool("smoothImageRendering"),
             detail: "Use smooth image rendering rather than pixelated rendering when resizing images",
-            handle: handleBool("smoothImageRendering", 2)
+            handle: handleBool("smoothImageRendering", i++)
         }),
         separator(),
         quickPickItem({

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -81,7 +81,7 @@ export const optionMenu: () => void = () =>
 
 const moreMenu: (selected?: number) => void = (selected?: number) => {
     const descriptionBool: (key: ConfigurationKey) => string = (key: ConfigurationKey) => `[$(${get(key) ? "check" : "close"})]`;
-    const handleBool: (key: ConfigurationKey, index: number) => (item: CommandQuickPickItem) => void = (key: ConfigurationKey, index: number) => () => update(key, !get(key)).then(() => moreMenu(index));
+    const handleBool: (key: ConfigurationKey, index: number, skipNotification?: boolean) => (item: CommandQuickPickItem) => void = (key: ConfigurationKey, index: number, skipNotification?: boolean) => () => update(key, !get(key), undefined, skipNotification).then(() => moreMenu(index));
 
     let i = 0;
 
@@ -90,7 +90,7 @@ const moreMenu: (selected?: number) => void = (selected?: number) => {
             label: "Auto Install",
             description: descriptionBool("autoInstall"),
             detail: "Automatically install background on startup or when VSCode updates",
-            handle: handleBool("autoInstall", i++)
+            handle: handleBool("autoInstall", i++, true)
         }),
         quickPickItem({
             label: "Render Content Above Background",

--- a/src/menu/opacity.ts
+++ b/src/menu/opacity.ts
@@ -44,7 +44,7 @@ export const show: (ui: UI) => void = (ui: UI) => {
         handle: (value: string) => {
             if(!isNaN(+value)){
                 const o: number = Math.min(Math.max(round(+value, 2), 0), 1);
-                if(o > .9){
+                if(get("useInvertedOpacity") ? o > .1 : o < .9){
                     update("backgroundOpacity", o, ui)
                         .then(() => backgroundMenu(ui)); // reopen menu
                 }else{

--- a/src/menu/opacity.ts
+++ b/src/menu/opacity.ts
@@ -44,7 +44,7 @@ export const show: (ui: UI) => void = (ui: UI) => {
         handle: (value: string) => {
             if(!isNaN(+value)){
                 const o: number = Math.min(Math.max(round(+value, 2), 0), 1);
-                if(o > .1){
+                if(o > .9){
                     update("backgroundOpacity", o, ui)
                         .then(() => open(ui)); // reopen menu
                 }else{


### PR DESCRIPTION
### Relevant Issues
*List any closed and/or relevant issues*

 * Closes #370

### Changes Made
*List any changes made.*

 * Invert opacity calculation
 * Add option to use old behavior

#### Release Notes

Going forward, to achieve parity with other background extensions, the opacity calculation will be switched from 0 visible and 1 invisible to 1 visible and 0 invisible.

To use the old behavior, use the **useInvertedOpacity** option. If you already have an opacity set, the inverted opacity setting will automatically be turned on.