### PR TITLE
Add option to save settings per-workspace

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -14,6 +14,10 @@ This extension also modifies `%LocalAppData%\Programs\Microsoft VS Code\resource
 
 ## &nbsp;
 
+### Backgrounds are missing on workspace
+
+The workspace setting will use whatever settings are set for that workspace, it does not fallback to the global setting.
+
 ### Disable/uninstall doesn't remove background
 
 Backgrounds are not removed on extension disable or uninstall, you must run the **Background: Uninstall** command to remove backgrounds.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The order settings are saved in is:
 |`background.autoInstall`|`boolean`|Automatically installs backgrounds and reloads the window on startup if changes are detected or VSCode updates.<br>This option is disabled when you run the uninstall command.|
 |`background.renderContentAboveBackground`|`boolean`|Render content like images, PDFs, and markdown previews above the background.|
 |`background.smoothImageRendering`|`boolean`|Use smooth image rendering rather than pixelated rendering when resizing images.|
+|`background.settingScope`|`Global` \| `Workspace`|Where to save background settings.|
 |`background.CSS`|`string`|Apply raw CSS to VSCode.|
 
 <div align="right"><a href="#top"><code>▲</code></a></div>

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The order settings are saved in is:
 |`background.autoInstall`|`boolean`|Automatically installs backgrounds and reloads the window on startup if changes are detected or VSCode updates.<br>This option is disabled when you run the uninstall command.|
 |`background.renderContentAboveBackground`|`boolean`|Render content like images, PDFs, and markdown previews above the background.|
 |`background.smoothImageRendering`|`boolean`|Use smooth image rendering rather than pixelated rendering when resizing images.|
-|`background.settingScope`|`Global` \| `Workspace`|Where to save background settings. If set to `Workspace`, the workspace settings will be used and fallback to the `Global` setting if not set.|
+|`background.settingScope`|`Global` \| `Workspace`|Where to save background settings. If set to `Workspace`, the workspace settings will be used and fallback to the `Global` setting if not set. Does not automatically update the background on workspace change, `autoInstall` needs to set to true.|
 |`background.CSS`|`string`|Apply raw CSS to VSCode.|
 
 <div align="right"><a href="#top"><code>▲</code></a></div>

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The order settings are saved in is:
 |`background.autoInstall`|`boolean`|Automatically installs backgrounds and reloads the window on startup if changes are detected or VSCode updates.<br>This option is disabled when you run the uninstall command.|
 |`background.renderContentAboveBackground`|`boolean`|Render content like images, PDFs, and markdown previews above the background.|
 |`background.smoothImageRendering`|`boolean`|Use smooth image rendering rather than pixelated rendering when resizing images.|
-|`background.settingScope`|`Global` \| `Workspace`|Where to save background settings.|
+|`background.settingScope`|`Global` \| `Workspace`|Where to save background settings. If set to `Workspace`, the workspace settings will be used and fallback to the `Global` setting if not set.|
 |`background.CSS`|`string`|Apply raw CSS to VSCode.|
 
 <div align="right"><a href="#top"><code>▲</code></a></div>

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The order settings are saved in is:
 |`background.autoInstall`|`boolean`|Automatically installs backgrounds and reloads the window on startup if changes are detected or VSCode updates.<br>This option is disabled when you run the uninstall command.|
 |`background.renderContentAboveBackground`|`boolean`|Render content like images, PDFs, and markdown previews above the background.|
 |`background.smoothImageRendering`|`boolean`|Use smooth image rendering rather than pixelated rendering when resizing images.|
-|`background.settingScope`|`Global` \| `Workspace`|Where to save background settings. If set to `Workspace`, the workspace settings will be used and fallback to the `Global` setting if not set. Does not automatically update the background on workspace change, `autoInstall` needs to set to true.|
+|`background.settingScope`|`Global` \| `Workspace`|Where to save background settings. This does not automatically update the background on workspace change, you need to also turn on `autoInstall`.|
 |`background.CSS`|`string`|Apply raw CSS to VSCode.|
 
 <div align="right"><a href="#top"><code>▲</code></a></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "code-background",
-    "version": "2.10.4",
+    "version": "3.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "code-background",
-            "version": "2.10.4",
+            "version": "3.0.0",
             "license": "GPL-2.0-only",
             "devDependencies": {
                 "@types/node": "22.1.0",

--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
                     "default": false
                 },
                 "background.settingScope": {
-                    "markdownDescription": "Where to save background settings. If set to `Workspace`, the workspace settings will be used and fallback to the `Global` setting if not set.",
+                    "markdownDescription": "Where to save background settings. If set to `Workspace`, the workspace settings will be used and fallback to the `Global` setting if not set.\n\nThis does not automatically update the background on workspace change, you need to also turn on `#background.autoInstall#`.",
                     "order": 15,
                     "type": "string",
                     "enum": [

--- a/package.json
+++ b/package.json
@@ -326,7 +326,8 @@
         "vscode:prepublish": "npm run prepare",
         "build:esbuild": "esbuild src/extension.ts --bundle --outfile=dist/index.js --external:vscode --format=cjs --platform=node --minify --legal-comments=none --metafile=meta.json",
         "build:post": "node build.js",
-        "build": "npm run build:esbuild && npm run build:post",
+        "tsc": "tsc -noEmit",
+        "build": "tsc --noEmit && npm run build:esbuild && npm run build:post",
         "prepare": "npm run clean && npm run build",
         "// -- deploy -- //": "",
         "package": "vsce package"

--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
                     "default": false
                 },
                 "background.settingScope": {
-                    "markdownDescription": "Where to save background settings. If set to `Workspace`, the workspace settings will be used and fallback to the `Global` setting if not set.\n\nThis does not automatically update the background on workspace change, you need to also turn on `#background.autoInstall#`.",
+                    "markdownDescription": "Where to save and load background settings.\n\nThis does not automatically update the background on workspace change, you need to also turn on `#background.autoInstall#`.",
                     "order": 15,
                     "type": "string",
                     "enum": [

--- a/package.json
+++ b/package.json
@@ -326,7 +326,6 @@
         "vscode:prepublish": "npm run prepare",
         "build:esbuild": "esbuild src/extension.ts --bundle --outfile=dist/index.js --external:vscode --format=cjs --platform=node --minify --legal-comments=none --metafile=meta.json",
         "build:post": "node build.js",
-        "tsc": "tsc -noEmit",
         "build": "tsc --noEmit && npm run build:esbuild && npm run build:post",
         "prepare": "npm run clean && npm run build",
         "// -- deploy -- //": "",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "theme": "dark"
     },
     "publisher": "Katsute",
-    "version": "2.10.4",
+    "version": "3.0.0",
     "private": true,
     "engines": {
         "vscode": "^1.92.0"

--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
                     "default": false
                 },
                 "background.settingScope": {
-                    "markdownDescription": "Where to save background settings.",
+                    "markdownDescription": "Where to save background settings. If set to `Workspace`, the workspace settings will be used and fallback to the `Global` setting if not set.",
                     "order": 15,
                     "type": "string",
                     "enum": [

--- a/package.json
+++ b/package.json
@@ -286,15 +286,25 @@
                 },
                 "background.renderContentAboveBackground": {
                     "markdownDescription": "Render content like images, PDFs, and markdown previews above the background.",
-                    "order": 14,
+                    "order": 13,
                     "type": "boolean",
                     "default": false
                 },
                 "background.smoothImageRendering": {
                     "markdownDescription": "Use smooth image rendering rather than pixelated rendering when resizing images.",
-                    "order": 15,
+                    "order": 14,
                     "type": "boolean",
                     "default": false
+                },
+                "background.settingScope": {
+                    "markdownDescription": "Where to save background settings.",
+                    "order": 15,
+                    "type": "string",
+                    "enum": [
+                        "Global",
+                        "Workspace"
+                    ],
+                    "default": "Global"
                 },
                 "background.CSS": {
                     "markdownDescription": "Apply raw CSS to VSCode.",

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -127,7 +127,8 @@ export const update: (key: ConfigurationKey, value: any, ui?: UI, skipNotificati
         changed = current[i] !== value;
         current[i] = value;
 
-        await configuration().update(key, current, ConfigurationTarget.Global);
+        // update to workspace if scope is workspace and in a workspace | default to global
+        await configuration().update(key, current, get("settingScope") === "Workspace" && workspace.workspaceFolders ? ConfigurationTarget.Workspace : ConfigurationTarget.Global);
     }
     skipNotification === false && changed && notify();
 }

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -51,16 +51,29 @@ export const notify: () => void = () =>
 
 export const get: (key: ConfigurationKey, ui?: UI) => any = (key: ConfigurationKey, ui?: UI) => {
     const option = configuration().inspect(key);
-    return  !ui
-            ? option!.globalValue ?? option!.defaultValue // non ui use global option
-            : target() === ConfigurationTarget.Workspace
-                    // use workspace, default to global
-                ?      (option!.workspaceValue as any[] | undefined)?.[Index(ui)]
-                    ?? (option!.globalValue as any[] | undefined)?.[Index(ui)]
-                    ?? (option!.defaultValue as any[])[Index(ui)]
-                    // use global
-                :      (option!.globalValue as any[] | undefined)?.[Index(ui)]
-                    ?? (option!.defaultValue as any[])[Index(ui)];
+    if(Array.isArray(option!.defaultValue)){ // background setting
+        if(option!.defaultValue.length === 0){ // actual backgrounds
+            if(target() === ConfigurationTarget.Workspace){ // workspace setting, fallback to global
+                return (option!.workspaceValue as any[] | undefined)
+                    ?? (option!.globalValue as any[] | undefined)
+                    ?? (option!.defaultValue as any[]);
+            }else{ // global setting
+                return (option!.globalValue as any[] | undefined)
+                    ?? (option!.defaultValue as any[]);
+            }
+        }else{ // settings (opacity, pos, timer, etc.)
+            if(target() === ConfigurationTarget.Workspace){ // workspace setting, fallback to global
+                return (option!.workspaceValue as any[] | undefined)?.[Index(ui!)]
+                    ?? (option!.globalValue as any[] | undefined)?.[Index(ui!)]
+                    ?? (option!.defaultValue as any[])[Index(ui!)];
+            }else{ // global setting
+                return (option!.globalValue as any[] | undefined)?.[Index(ui!)]
+                    ?? (option!.defaultValue as any[])[Index(ui!)];
+            }
+        }
+    }else{ // global setting
+        return option?.globalValue ?? option!.defaultValue;
+    }
 }
 
 export const getCSS: (key: ConfigurationKey, ui: UI) => string = (key: ConfigurationKey, ui: UI) => {

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -152,7 +152,8 @@ export const update: (key: ConfigurationKey, value: any, ui?: UI, skipNotificati
     let changed: boolean = false;
     if(!ui){
         changed = get(key) !== value;
-        await configuration().update(key, value, ConfigurationTarget.Global); // non ui settings are global
+        // if value is array, then it is the background[] array and should use targeted scope, otherwise it is a config setting and should be global
+        await configuration().update(key, value, Array.isArray(value) ? target() : ConfigurationTarget.Global);
     }else{
         const current: any = get(key);
 

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -49,15 +49,19 @@ export const notify: () => void = () =>
 
 // get
 
-export const get: (key: ConfigurationKey, ui?: UI) => any = (key: ConfigurationKey, ui?: UI) =>
-    !ui
-    ? configuration().get(key) // non ui settings are global
-      ?? getConfigurationProperty(key).default
-      ?? "null"
-    // use first workspace for settings if set, default to global
-    : (configuration(target() === ConfigurationTarget.Workspace && workspace.workspaceFolders![0] ? workspace.workspaceFolders![0] : null).get(key) as any[])[Index(ui)]
-      ?? getConfigurationProperty(key).default[0]
-      ?? "null";
+export const get: (key: ConfigurationKey, ui?: UI) => any = (key: ConfigurationKey, ui?: UI) => {
+    const option = configuration().inspect(key);
+    return  !ui
+            ? option!.globalValue ?? option!.defaultValue // non ui use global option
+            : target() === ConfigurationTarget.Workspace
+                    // use workspace, default to global
+                ?      (option!.workspaceValue as any[] | undefined)?.[Index(ui)]
+                    ?? (option!.globalValue as any[] | undefined)?.[Index(ui)]
+                    ?? (option!.defaultValue as any[])[Index(ui)]
+                    // use global
+                :      (option!.globalValue as any[] | undefined)?.[Index(ui)]
+                    ?? (option!.defaultValue as any[])[Index(ui)];
+}
 
 export const getCSS: (key: ConfigurationKey, ui: UI) => string = (key: ConfigurationKey, ui: UI) => {
     const value: string = get(key, ui);

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -95,7 +95,7 @@ export const get: (key: ConfigurationKey, options?: {
 }
 
 export const getCSS: (key: ConfigurationKey, ui: UI) => string = (key: ConfigurationKey, ui: UI) => {
-    const value: string = get(key, {ui});
+    const value: string = get(key, {ui, fallback: true});
     const prop: Properties = getConfigurationProperty(key);
 
     switch(key){

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -47,10 +47,10 @@ export const clean: (content: string) => string = (s: string) =>
 
 const getJavaScript: () => string = () => {
     const images: {[key: string]: string[]} = {
-        window:  resolve(get("windowBackgrounds")),
-        editor:  resolve(get("editorBackgrounds")),
-        sidebar: resolve(get("sidebarBackgrounds")),
-        panel:   resolve(get("panelBackgrounds"))
+        window:  resolve(get("windowBackgrounds", {fallback: true})),
+        editor:  resolve(get("editorBackgrounds", {fallback: true})),
+        sidebar: resolve(get("sidebarBackgrounds", {fallback: true})),
+        panel:   resolve(get("panelBackgrounds", {fallback: true}))
     };
 
     const after: boolean = get("renderContentAboveBackground");
@@ -112,10 +112,10 @@ const iEditorBackgrounds = [...Array(${images.editor.length}).keys()];
 const iSidebarBackgrounds = [...Array(${images.sidebar.length}).keys()];
 const iPanelBackgrounds = [...Array(${images.panel.length}).keys()];
 
-const windowTime = ${get("backgroundChangeTime", "window") == 0 ? 0 : Math.max(round(get("backgroundChangeTime", "window"), 2), 5)};
-const editorTime = ${get("backgroundChangeTime", "editor") == 0 ? 0 : Math.max(round(get("backgroundChangeTime", "editor"), 2), 5)};
-const sidebarTime = ${get("backgroundChangeTime", "sidebar") == 0 ? 0 : Math.max(round(get("backgroundChangeTime", "sidebar"), 2), 5)};
-const panelTime = ${get("backgroundChangeTime", "panel") == 0 ? 0 : Math.max(round(get("backgroundChangeTime", "panel"), 2), 5)};
+const windowTime = ${get("backgroundChangeTime", {ui: "window", fallback: true}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "window", fallback: true}), 2), 5)};
+const editorTime = ${get("backgroundChangeTime", {ui: "editor", fallback: true}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "editor", fallback: true}), 2), 5)};
+const sidebarTime = ${get("backgroundChangeTime", {ui: "sidebar", fallback: true}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "sidebar", fallback: true}), 2), 5)};
+const panelTime = ${get("backgroundChangeTime", {ui: "panel", fallback: true}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "panel"}), 2), 5)};
 `
 + // individual background css - window
 `

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -47,10 +47,10 @@ export const clean: (content: string) => string = (s: string) =>
 
 const getJavaScript: () => string = () => {
     const images: {[key: string]: string[]} = {
-        window:  resolve(get("windowBackgrounds", {fallback: true})),
-        editor:  resolve(get("editorBackgrounds", {fallback: true})),
-        sidebar: resolve(get("sidebarBackgrounds", {fallback: true})),
-        panel:   resolve(get("panelBackgrounds", {fallback: true}))
+        window:  resolve(get("windowBackgrounds")),
+        editor:  resolve(get("editorBackgrounds")),
+        sidebar: resolve(get("sidebarBackgrounds")),
+        panel:   resolve(get("panelBackgrounds"))
     };
 
     const after: boolean = get("renderContentAboveBackground");
@@ -112,10 +112,10 @@ const iEditorBackgrounds = [...Array(${images.editor.length}).keys()];
 const iSidebarBackgrounds = [...Array(${images.sidebar.length}).keys()];
 const iPanelBackgrounds = [...Array(${images.panel.length}).keys()];
 
-const windowTime = ${get("backgroundChangeTime", {ui: "window", fallback: true}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "window", fallback: true}), 2), 5)};
-const editorTime = ${get("backgroundChangeTime", {ui: "editor", fallback: true}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "editor", fallback: true}), 2), 5)};
-const sidebarTime = ${get("backgroundChangeTime", {ui: "sidebar", fallback: true}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "sidebar", fallback: true}), 2), 5)};
-const panelTime = ${get("backgroundChangeTime", {ui: "panel", fallback: true}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "panel"}), 2), 5)};
+const windowTime = ${get("backgroundChangeTime", {ui: "window"}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "window"}), 2), 5)};
+const editorTime = ${get("backgroundChangeTime", {ui: "editor"}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "editor"}), 2), 5)};
+const sidebarTime = ${get("backgroundChangeTime", {ui: "sidebar"}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "sidebar"}), 2), 5)};
+const panelTime = ${get("backgroundChangeTime", {ui: "panel"}) == 0 ? 0 : Math.max(round(get("backgroundChangeTime", {ui: "panel"}), 2), 5)};
 `
 + // individual background css - window
 `

--- a/src/extension/package.ts
+++ b/src/extension/package.ts
@@ -33,6 +33,7 @@ export type ConfigurationKey =
     "backgroundChangeTime" |
     "autoInstall" |
     "renderContentAboveBackground" |
+    "settingScope" |
     "smoothImageRendering" |
     "CSS";
 

--- a/src/menu/align.ts
+++ b/src/menu/align.ts
@@ -31,7 +31,7 @@ const handle: (item: CommandQuickPickItem) => void = (item: CommandQuickPickItem
         .then(() => backgroundMenu(item.ui!)); // reopen menu
 
 export const show: (ui: UI) => void = (ui: UI) => {
-    const current: string = get("backgroundAlignment", ui);
+    const current: string = get("backgroundAlignment", {ui});
 
     showQuickPick([
         // top
@@ -51,10 +51,10 @@ export const show: (ui: UI) => void = (ui: UI) => {
         // manual
         separator(),
         quickPickItem({ label: prop.items!.enum![9],
-            description: `(${get("backgroundAlignmentValue", ui)})`,
+            description: `(${get("backgroundAlignmentValue", {ui})})`,
             ui,
             handle: (item: CommandQuickPickItem) => {
-                const currentValue: string = get("backgroundAlignmentValue", ui);
+                const currentValue: string = get("backgroundAlignmentValue", {ui});
                 showInputBox({
                     title: title("Alignment", ui),
                     placeHolder: "Background position",
@@ -63,7 +63,7 @@ export const show: (ui: UI) => void = (ui: UI) => {
                     validateInput: (value: string) => !isValidCSS(value) ? "Invalid CSS" : null,
                     handle: (value: string) => {
                         if(isValidCSS(value)){
-                            let changed: boolean = get("backgroundAlignment", ui) !== prop.items!.enum![9] || currentValue !== value;
+                            let changed: boolean = get("backgroundAlignment", {ui}) !== prop.items!.enum![9] || currentValue !== value;
 
                             update("backgroundAlignment", prop.items!.enum![9], ui, true)
                                 .then(() => update("backgroundAlignmentValue", value, ui, true))

--- a/src/menu/blur.ts
+++ b/src/menu/blur.ts
@@ -24,7 +24,7 @@ import { showInputBox } from "../lib/vscode";
 import { backgroundMenu, title } from "./menu";
 
 export const show: (ui: UI) => void = (ui: UI) => {
-    const current: string = get("backgroundBlur", ui) as string;
+    const current: string = get("backgroundBlur", {ui}) as string;
 
     showInputBox({
         title: title("Blur", ui),

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -17,10 +17,10 @@
  */
 
 import { platform, release } from "os";
-import { Uri, commands, env, version } from "vscode";
+import { ConfigurationTarget, Uri, commands, env, version } from "vscode";
 
 import { ConfigurationKey, pkg } from "../extension/package";
-import { UI, configuration, get, update } from "../extension/config";
+import { UI, configuration, get, target, update } from "../extension/config";
 
 import { count } from "../lib/glob";
 import { appendS, appendIf, capitalize } from "../lib/string";
@@ -73,7 +73,7 @@ export const optionMenu: () => void = () =>
             handle: () => commands.executeCommand("background.help")
         }),
     ], {
-        title: "Background",
+        title: "Background" + (target() === ConfigurationTarget.Workspace ? " (Workspace)": ""),
         matchOnDescription: true
     });
 
@@ -220,7 +220,7 @@ export const backgroundMenu: (ui: UI) => void = (ui: UI) =>
             handle: () => timeMenu(ui)
         })
     ], {
-        title: `${capitalize(ui)} Background`,
+        title: `${capitalize(ui)} Background` + (target() === ConfigurationTarget.Workspace ? " (Workspace)": ""),
         matchOnDescription: true,
         matchOnDetail: true
     }, optionMenu);

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -142,14 +142,14 @@ const getQuickPick: (ui: UI, icon: string) => CommandQuickPickItem = (ui: UI, ic
 
     // detail
     let detail: string =
-        `${get("backgroundAlignment", ui)} Alignment` + " • " +
-        `${get("backgroundBlur",      ui)} Blur`      + " • " +
-        `${get("backgroundOpacity",   ui)} Opacity`   + " • " +
-        `${get("backgroundRepeat",    ui)} Repeat`    + " • " +
-        `${get("backgroundSize",      ui)} Size`;
+        `${get("backgroundAlignment", {ui})} Alignment` + " • " +
+        `${get("backgroundBlur",      {ui})} Blur`      + " • " +
+        `${get("backgroundOpacity",   {ui})} Opacity`   + " • " +
+        `${get("backgroundRepeat",    {ui})} Repeat`    + " • " +
+        `${get("backgroundSize",      {ui})} Size`;
 
     // only include time if nonzero (enabled)
-    const time: number = +get("backgroundChangeTime", ui);
+    const time: number = +get("backgroundChangeTime", {ui});
 
     if(time > 0)
         detail += " • " + appendS(time, "second");
@@ -179,42 +179,42 @@ export const backgroundMenu: (ui: UI) => void = (ui: UI) =>
         separator(),
         quickPickItem({
             label: "$(arrow-both) Alignment",
-            description: `${appendIf(get("backgroundAlignment", ui), s => s === "Manual", ` (${get("backgroundAlignmentValue", ui)})`)}`,
+            description: `${appendIf(get("backgroundAlignment", {ui}), s => s === "Manual", ` (${get("backgroundAlignmentValue", {ui})})`)}`,
             detail: "Background image alignment",
             ui,
             handle: () => alignMenu(ui)
         }),
         quickPickItem({
             label: "$(eye) Blur",
-            description: `${get("backgroundBlur", ui)}`,
+            description: `${get("backgroundBlur", {ui})}`,
             detail: "Background image blur",
             ui,
             handle: () => blurMenu(ui)
         }),
         quickPickItem({
             label: "$(color-mode) Opacity",
-            description: `${get("backgroundOpacity", ui)}`,
+            description: `${get("backgroundOpacity", {ui})}`,
             detail: "Background image opacity",
             ui,
             handle: () => opacityMenu(ui)
         }),
         quickPickItem({
             label: "$(multiple-windows) Repeat",
-            description: `${get("backgroundRepeat", ui)}`,
+            description: `${get("backgroundRepeat", {ui})}`,
             detail: "Background image repeat",
             ui,
             handle: () => repeatMenu(ui)
         }),
         quickPickItem({
             label: "$(screen-full) Size",
-            description: `${appendIf(get("backgroundSize", ui), s => s === "Manual", ` (${get("backgroundSizeValue", ui)})`)}`,
+            description: `${appendIf(get("backgroundSize", {ui}), s => s === "Manual", ` (${get("backgroundSizeValue", {ui})})`)}`,
             detail: "Background image size",
             ui,
             handle: () => sizeMenu(ui)
         }),
         quickPickItem({
             label: "$(clock) Time",
-            description: `${appendS(+get("backgroundChangeTime", ui), "second")}`,
+            description: `${appendS(+get("backgroundChangeTime", {ui}), "second")}`,
             detail: "How often to change the background",
             ui,
             handle: () => timeMenu(ui)

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -102,6 +102,12 @@ const moreMenu: (selected?: number) => void = (selected?: number) => {
             detail: "Use smooth image rendering rather than pixelated rendering when resizing images",
             handle: handleBool("smoothImageRendering", 2)
         }),
+        quickPickItem({
+            label: "Setting Scope",
+            description: `[${get("settingScope")}]`,
+            detail: "Where to save background settings",
+            handle: () => update("settingScope", get("settingScope") === "Global" ? "Workspace" : "Global").then(() => moreMenu(3))
+        }),
         separator(),
         quickPickItem({
             label: "$(output) Changelog",

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -92,20 +92,20 @@ const moreMenu: (selected?: number) => void = (selected?: number) => {
         }),
         quickPickItem({
             label: "Render Content Above Background",
-            description: `[$(${get("renderContentAboveBackground") ? "check" : "close"})]`,
+            description: descriptionBool("renderContentAboveBackground"),
             detail: "Render content like images, PDFs, and markdown previews above the background",
             handle: handleBool("renderContentAboveBackground", 1)
         }),
         quickPickItem({
             label: "Smooth Image Rendering",
-            description: `[$(${get("smoothImageRendering") ? "check" : "close"})]`,
+            description: descriptionBool("smoothImageRendering"),
             detail: "Use smooth image rendering rather than pixelated rendering when resizing images",
             handle: handleBool("smoothImageRendering", 2)
         }),
         quickPickItem({
             label: "Setting Scope",
             description: `[${get("settingScope")}]`,
-            detail: "Where to save background settings",
+            detail: "Where to save settings; workspace requires Auto Install to update background on switch",
             handle: () => update("settingScope", get("settingScope") === "Global" ? "Workspace" : "Global").then(() => moreMenu(3))
         }),
         separator(),

--- a/src/menu/opacity.ts
+++ b/src/menu/opacity.ts
@@ -26,7 +26,7 @@ import { showInputBox } from "../lib/vscode";
 import { backgroundMenu, title } from "./menu";
 
 export const show: (ui: UI) => void = (ui: UI) => {
-    const current: number = round(get("backgroundOpacity", ui) as number, 2);
+    const current: number = round(get("backgroundOpacity", {ui}) as number, 2);
 
     showInputBox({
         title: title("Opacity", ui),

--- a/src/menu/repeat.ts
+++ b/src/menu/repeat.ts
@@ -30,7 +30,7 @@ const handle: (item: CommandQuickPickItem) => void = (item: CommandQuickPickItem
         .then(() => backgroundMenu(item.ui!)); // reopen menu
 
 export const show: (ui: UI) => void = (ui: UI) => {
-    const current: string = get("backgroundRepeat", ui) as string;
+    const current: string = get("backgroundRepeat", {ui}) as string;
 
     showQuickPick([
         quickPickItem({ label: prop.items!.enum![0], description: prop.items!.enumDescriptions![0], handle: handle, ui }, current),

--- a/src/menu/size.ts
+++ b/src/menu/size.ts
@@ -31,7 +31,7 @@ const handle: (item: CommandQuickPickItem) => void = (item: CommandQuickPickItem
         .then(() => backgroundMenu(item.ui!)); // reopen menu
 
 export const show: (ui: UI) => void = (ui: UI) => {
-    const current: string = get("backgroundSize", ui) as string;
+    const current: string = get("backgroundSize", {ui}) as string;
 
     showQuickPick([
         // size
@@ -40,8 +40,8 @@ export const show: (ui: UI) => void = (ui: UI) => {
         quickPickItem({ label: prop.items!.enum![2], description: prop.items!.enumDescriptions![2], handle, ui }, current),
         separator(),
         // manual
-        quickPickItem({ label: prop.items!.enum![3], description: `(${get("backgroundSizeValue", ui)})`, ui: ui, handle: (item: CommandQuickPickItem) => {
-            const currentValue: string = get("backgroundSizeValue", ui);
+        quickPickItem({ label: prop.items!.enum![3], description: `(${get("backgroundSizeValue", {ui})})`, ui: ui, handle: (item: CommandQuickPickItem) => {
+            const currentValue: string = get("backgroundSizeValue", {ui});
             showInputBox({
                 title: title("Size", ui),
                 placeHolder: "Background size",
@@ -50,7 +50,7 @@ export const show: (ui: UI) => void = (ui: UI) => {
                 validateInput: (value: string) => !isValidCSS(value) ? "Invalid CSS" : null,
                 handle: (value: string) => {
                     if(isValidCSS(value)){
-                        let changed: boolean = get("backgroundSize", ui) !== prop.items!.enum![3] || currentValue !== value;
+                        let changed: boolean = get("backgroundSize", {ui}) !== prop.items!.enum![3] || currentValue !== value;
 
                         update("backgroundSize", prop.items!.enum![3], ui, true)
                             .then(() => update("backgroundSizeValue", value, ui, true))

--- a/src/menu/time.ts
+++ b/src/menu/time.ts
@@ -24,7 +24,7 @@ import { showInputBox } from "../lib/vscode";
 import { backgroundMenu, title } from "./menu";
 
 export const show: (ui: UI) => void = (ui: UI) => {
-    const current: number = round(get("backgroundChangeTime", ui) as number, 2);
+    const current: number = round(get("backgroundChangeTime", {ui}) as number, 2);
 
     showInputBox({
         title: title("Change Time", ui),


### PR DESCRIPTION
### Relevant Issues
*List any closed and/or relevant issues*

 * Closes #381

### Changes Made
*List any changes made.*

 * Add typecheck to build
 * Adds option to save background settings to workspace
 * Install uses workspace with global fallback
 * Background menu uses workspace without fallback
 * Background menu specifies global value
 * Default is returned in all cases

#### Release Notes

This updates the configuration menu to allow workspace specific settings; to use workspace, toggle the **Setting Scope** in the more options menu. Does not automatically update the background on workspace switch, the **Auto Install** option needs to also be turned on.

Setting this to workspace will always use the workspace configuration, it does not fallback to global settings.