### PR TITLE
Require API access to be enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /node_modules
 /dist
 
-/.vscode-test
+.vscode-test
 
 /test/__*
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Use the <kbd>Background: Configuration</kbd> command or press the **Background**
 |Smooth Image Rendering|Use smooth image rendering when resizing images instead of pixelated|
 |Setting Scope|Where to save background settings - Global or Workspace|
 |CSS|Custom CSS|
+|API|Toggles API access|
 
 <div align="right"><a href="#top"><code>▲</code></a></div>
 
@@ -126,6 +127,8 @@ If the path is not working, add an additional `/` after the variable.
 ## &nbsp;
 
 ### API
+
+*Requires API setting to be turned on in the extension*
 
 Add this extension to your `package.json`.
 

--- a/package.json
+++ b/package.json
@@ -318,6 +318,12 @@
                     "type": "string",
                     "editPresentation": "multilineText",
                     "default": ""
+                },
+                "background.API": {
+                    "markdownDescription": "Enable API access.",
+                    "order": 18,
+                    "type": "boolean",
+                    "default": false
                 }
             }
         }

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -18,15 +18,15 @@
 
 import { commands } from "vscode";
 import { add, get, remove, replace } from "../menu/file";
-import { get as get2 } from "./config";
+import { get as cget } from "./config";
 import { reload } from "../lib/vscode";
 
 export const api = {
-    install: () => get2("API") && commands.executeCommand("background.install"),
-    uninstall: () => get2("API") && commands.executeCommand("background.uninstall"),
+    install: () => cget("API") && commands.executeCommand("background.install"),
+    uninstall: () => cget("API") && commands.executeCommand("background.uninstall"),
     reload,
     get: (ui: string) => {
-        if(get2("API"))
+        if(cget("API"))
             switch(ui){
                 case "window":
                 case "editor":
@@ -40,7 +40,7 @@ export const api = {
             return undefined;
     },
     add: async (ui: string, glob: string) => {
-        if(get2("API"))
+        if(cget("API"))
             switch(ui){
                 case "window":
                 case "editor":
@@ -55,7 +55,7 @@ export const api = {
             return false;
     },
     replace: async (ui: string, old: string, glob: string) => {
-        if(get2("API"))
+        if(cget("API"))
             switch(ui){
                 case "window":
                 case "editor":
@@ -70,7 +70,7 @@ export const api = {
             return false;
     },
     remove: async (ui: string, glob: string) => {
-        if(get2("API"))
+        if(cget("API"))
             switch(ui){
                 case "window":
                 case "editor":

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -18,57 +18,70 @@
 
 import { commands } from "vscode";
 import { add, get, remove, replace } from "../menu/file";
+import { get as get2 } from "./config";
 import { reload } from "../lib/vscode";
 
 export const api = {
-    install: () => commands.executeCommand("background.install"),
-    uninstall: () => commands.executeCommand("background.uninstall"),
+    install: () => get2("API") && commands.executeCommand("background.install"),
+    uninstall: () => get2("API") && commands.executeCommand("background.uninstall"),
     reload,
     get: (ui: string) => {
-        switch(ui){
-            case "window":
-            case "editor":
-            case "sidebar":
-            case "panel":
-                return get(ui);
-            default:
-                return undefined;
-        }
+        if(get2("API"))
+            switch(ui){
+                case "window":
+                case "editor":
+                case "sidebar":
+                case "panel":
+                    return get(ui);
+                default:
+                    return undefined;
+            }
+        else
+            return undefined;
     },
     add: async (ui: string, glob: string) => {
-        switch(ui){
-            case "window":
-            case "editor":
-            case "sidebar":
-            case "panel":
-                await add(ui, glob, true);
-                return true;
-            default:
-                return false;
-        }
+        if(get2("API"))
+            switch(ui){
+                case "window":
+                case "editor":
+                case "sidebar":
+                case "panel":
+                    await add(ui, glob, true);
+                    return true;
+                default:
+                    return false;
+            }
+        else
+            return false;
     },
     replace: async (ui: string, old: string, glob: string) => {
-        switch(ui){
-            case "window":
-            case "editor":
-            case "sidebar":
-            case "panel":
-                await replace(ui, old, glob, true);
-                return true;
-            default:
-                return false;
-        }
+        if(get2("API"))
+            switch(ui){
+                case "window":
+                case "editor":
+                case "sidebar":
+                case "panel":
+                    await replace(ui, old, glob, true);
+                    return true;
+                default:
+                    return false;
+            }
+        else
+            return false;
     },
     remove: async (ui: string, glob: string) => {
-        switch(ui){
-            case "window":
-            case "editor":
-            case "sidebar":
-            case "panel":
-                await remove(ui, glob, true);
-                return true;
-            default:
-                return false;
-        }
+        if(get2("API"))
+            switch(ui){
+                case "window":
+                case "editor":
+                case "sidebar":
+                case "panel":
+                    await remove(ui, glob, true);
+                    return true;
+                default:
+                    return false;
+            }
+        else
+            return false;
     }
 }

--- a/src/extension/package.ts
+++ b/src/extension/package.ts
@@ -36,7 +36,8 @@ export type ConfigurationKey =
     "useInvertedOpacity" |
     "settingScope" |
     "smoothImageRendering" |
-    "CSS";
+    "CSS" |
+    "API";
 
 export type Contributes = {
     commands: [{

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -116,6 +116,12 @@ const moreMenu: (selected?: number) => void = (selected?: number) => {
             detail: "Where to save settings; workspace requires Auto Install to update background on switch",
             handle: () => update("settingScope", get("settingScope") === "Global" ? "Workspace" : "Global").then(() => moreMenu(i++))
         }),
+        quickPickItem({
+            label: "API",
+            description: descriptionBool("API"),
+            detail: "Enable/disable API access",
+            handle: handleBool("API", i++)
+        }),
         separator(),
         quickPickItem({
             label: "$(output) Changelog",

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ const file = path.join(__dirname, "__testno__");
 
 const vscode = require("@vscode/test-electron");
 
-!fs.existsSync(file) || fs.unlinkSync(file);
+// !fs.existsSync(file) || fs.unlinkSync(file);
 
 vscode.runTests({
     extensionDevelopmentPath: path.join(__dirname, "../"),

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,8 @@ const images = path.join(__dirname, "*.png").replace(/\\/g, '/');
 
 module.exports = {
     run: () => new Promise(async () => {
+        await vscode.workspace.getConfiguration('background').update('API', true, vscode.ConfigurationTarget.Global);
+
         await wait(5);
 
         const background = vscode.extensions.getExtension("katsute.code-background").exports;

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ module.exports = {
                     await background.remove(ui, image);
             fs.writeFileSync(file, '0', "utf-8");
             background.install();
-        }else if((num = fs.readFileSync(file, "utf-8")) === 0){
+        }else if((num = parseInt(fs.readFileSync(file, "utf-8"))) === 0){
             vscode.window.showInformationMessage("Testing empty install");
 
             await wait(3);
@@ -75,6 +75,8 @@ module.exports = {
             await background.replace("window", images, images.replace(".png", ''));
 
             vscode.window.showInformationMessage(`All tests completed!\n\nBackgrounds are: \nwindow: [${await background.get("window")}]\neditor: [${await background.get("editor")}]\nsidebar: [${await background.get("sidebar")}]\npanel: [${await background.get("panel")}]`);
+
+            await vscode.workspace.getConfiguration('background').update('API', false, vscode.ConfigurationTarget.Global);
 
             fs.unlinkSync(file);
         }


### PR DESCRIPTION
### Relevant Issues
*List any closed and/or relevant issues*

 * #438 

### Changes Made
*List any changes made.*

 * Add API access option
 * Disable API access by default
 * Fixes to tests

#### Release Notes

It is now required to enable API access in the options menu in order to use the extension API.