### PR TITLE
Restore missing suggestion highlight when using render text over background option

### DIFF
--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -68,7 +68,10 @@ bk_global.setAttribute("type", "text/css");
 bk_global.appendChild(document.createTextNode(\`
 
     ${!under ? "" :
-    `body .split-view-view:nth-child(3) *:not([role="tooltip"], .monaco-count-badge, .badge-content, .label, .action-item *, .monaco-button, .view-overlays *, .sticky-widget *, .monaco-tree-sticky-container *, .lines-content *, .suggest-widget, .suggest-widget *), body > div {
+    `body .split-view-view:nth-child(3) *:not(
+        [role="tooltip"], .monaco-count-badge, .badge-content, .label, .action-item *, .monaco-button,
+        .view-overlays *, .sticky-widget *, .monaco-tree-sticky-container *, .lines-content *, .suggest-widget, .suggest-widget *),
+        body > div {
         background-color: unset !important;
     }`
     }


### PR DESCRIPTION
### Relevant Issues
*List any closed and/or relevant issues*

 * #550 

### Changes Made
*List any changes made.*

 * Fix suggest tooltop highlights

<img width="547" height="272" alt="image" src="https://github.com/user-attachments/assets/88834a7b-0155-4ff8-933e-ec5f1a1185c0" />
