### PR TITLE
refactor(UX): move “Back” action from list body to view title

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "theme": "dark"
     },
     "publisher": "Katsute",
-    "version": "4.0.4",
+    "version": "4.0.5",
     "private": true,
     "engines": {
         "vscode": "^1.109.0"


### PR DESCRIPTION
This PR relocates the backward navigation action.

Previously, the “Back” option was displayed as an item inside the list. This structurally mixed navigation elements with functional content.

The return action is now integrated into the view title (header), aligning with standard navigation patterns and improving:

* Clear separation between navigation and content
* Cleaner visual hierarchy
* Reduced noise inside the list
* Better alignment with modern UI conventions

No navigation logic has been changed — only its visual and structural representation.

### Relevant Issues

* Structural inconsistency in list view
* Navigation mixed with content elements

### Changes Made

* Removed “Back” option from list body
* Integrated return action into the view title
* Adjusted header styling
* Ensured functional parity of navigation behavior

### Visual diff

| Before | After |
|---|---|
|  <img width="699" height="470" alt="image" src="https://github.com/user-attachments/assets/923ba026-f8c0-4588-8632-fa7edf6a3c6f" /> |  <img width="693" height="444" alt="image" src="https://github.com/user-attachments/assets/049d9752-9093-415b-8151-4d4937c547ba" /> |
