### PR TITLE
Remove `Render Content Above Background` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ Use the <kbd>Background: Configuration</kbd> command or press the **Background**
 |||
 |**Advanced Option**|**Description**|
 |Auto Install|Automatically install backgrounds on startup|
-|Render Content Above Background|Show images, PDFs, and markdown previews on top of the background|
-|Render Text Above Background|Show text and code on top of the background, only supported for window backgrounds|
+|Render Text Above Background|Show text, code, browser, and iframes on top of the background, only supported for window backgrounds|
 |Use Inverted Opacity|Use an inverted opacity, so 0 is visible and 1 is invisible|
 |Smooth Image Rendering|Use smooth image rendering when resizing images instead of pixelated|
 |Setting Scope|Where to save background settings - Global or Workspace|

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
     <h3>Background</h3>
     <h4>The most advanced background image extension for VSCode</h4>
     <h5>Windows + Mac + Linux</h5>
-    <a href="https://marketplace.visualstudio.com/items?itemName=katsute.code-background"><img alt="rating" src="https://img.shields.io/visual-studio-marketplace/stars/katsute.code-background?style=for-the-badge&logo=visualstudiocode&labelColor=252526&color=0098FF&label=Rating"></a>
-    <a href="https://marketplace.visualstudio.com/items?itemName=katsute.code-background"><img alt="installs" src="https://img.shields.io/visual-studio-marketplace/i/katsute.code-background?style=for-the-badge&logo=visualstudiocode&labelColor=252526&color=0098FF&label=Installs"></a>
-    <a href="https://marketplace.visualstudio.com/items?itemName=katsute.code-background"><img alt="downloads" src="https://img.shields.io/visual-studio-marketplace/d/katsute.code-background?style=for-the-badge&logo=visualstudiocode&labelColor=252526&color=0098FF&label=Downloads"></a>
 </div>
 
 <br>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
     "name": "code-background",
-    "version": "4.0.4",
+    "version": "5.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "code-background",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "license": "GPL-2.0-only",
             "devDependencies": {
-                "@types/node": "25.6.0",
+                "@types/node": "25.9.1",
                 "@types/tmp": "0.2.6",
-                "@types/vscode": "1.118.0",
+                "@types/vscode": "1.120.0",
                 "@vscode/sudo-prompt": "9.3.1",
                 "@vscode/test-electron": "2.5.2",
                 "@vscode/vsce": "3.9.1",
@@ -22,7 +22,7 @@
                 "typescript": "6.0.3"
             },
             "engines": {
-                "vscode": "^1.118.0"
+                "vscode": "^1.121.0"
             }
         },
         "node_modules/@azu/format-text": {
@@ -1030,13 +1030,13 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "25.6.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+            "version": "25.9.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.19.0"
+                "undici-types": ">=7.24.0 <7.24.7"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -1061,9 +1061,9 @@
             "license": "MIT"
         },
         "node_modules/@types/vscode": {
-            "version": "1.118.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
-            "integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
+            "version": "1.120.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+            "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
             "dev": true,
             "license": "MIT"
         },
@@ -1309,9 +1309,9 @@
             }
         },
         "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2491,9 +2491,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3869,9 +3869,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -4848,9 +4848,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.19.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+            "version": "7.24.6",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
         "theme": "dark"
     },
     "publisher": "Katsute",
-    "version": "4.0.4",
+    "version": "5.0.0",
     "private": true,
     "engines": {
-        "vscode": "^1.118.0"
+        "vscode": "^1.121.0"
     },
     "categories": [
         "Other"
@@ -284,15 +284,9 @@
                     "type": "boolean",
                     "default": false
                 },
-                "background.renderContentAboveBackground": {
-                    "markdownDescription": "Render content like images, PDFs, and markdown previews above the background.",
-                    "order": 13,
-                    "type": "boolean",
-                    "default": false
-                },
                 "background.renderTextAboveBackground": {
                     "markdownDescription": "Render text and code above the background.\n\nOnly supported for window backgrounds.",
-                    "order": 14,
+                    "order": 13,
                     "type": "boolean",
                     "default": false
                 },
@@ -360,9 +354,9 @@
     },
     "homepage": "https://github.com/KatsuteDev/Background#readme",
     "devDependencies": {
-        "@types/node": "25.6.0",
+        "@types/node": "25.9.1",
         "@types/tmp": "0.2.6",
-        "@types/vscode": "1.118.0",
+        "@types/vscode": "1.120.0",
         "@vscode/sudo-prompt": "9.3.1",
         "@vscode/test-electron": "2.5.2",
         "@vscode/vsce": "3.9.1",

--- a/package.json
+++ b/package.json
@@ -285,7 +285,7 @@
                     "default": false
                 },
                 "background.renderTextAboveBackground": {
-                    "markdownDescription": "Render text and code above the background.\n\nOnly supported for window backgrounds.",
+                    "markdownDescription": "Show text, code, browser, and iframes on top of the background.\n\nOnly supported for window backgrounds.",
                     "order": 13,
                     "type": "boolean",
                     "default": false

--- a/package.json
+++ b/package.json
@@ -292,19 +292,19 @@
                 },
                 "background.useInvertedOpacity": {
                     "markdownDescription": "Use an inverted opacity, so 0 is fully visible and 1 is invisible.",
-                    "order": 15,
+                    "order": 14,
                     "type": "boolean",
                     "default": false
                 },
                 "background.smoothImageRendering": {
                     "markdownDescription": "Use smooth image rendering rather than pixelated rendering when resizing images.",
-                    "order": 16,
+                    "order": 15,
                     "type": "boolean",
                     "default": false
                 },
                 "background.settingScope": {
                     "markdownDescription": "Where to save and load background settings.\n\nThis does not automatically update the background on workspace change, you need to also turn on `#background.autoInstall#`.",
-                    "order": 17,
+                    "order": 16,
                     "type": "string",
                     "enum": [
                         "Global",
@@ -314,14 +314,14 @@
                 },
                 "background.CSS": {
                     "markdownDescription": "Apply raw CSS to VSCode.",
-                    "order": 18,
+                    "order": 17,
                     "type": "string",
                     "editPresentation": "multilineText",
                     "default": ""
                 },
                 "background.API": {
                     "markdownDescription": "Enable API access.",
-                    "order": 19,
+                    "order": 18,
                     "type": "boolean",
                     "default": false
                 }

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -53,10 +53,9 @@ const getJavaScript: () => string = () => {
         panel:   resolve(get("panelBackgrounds"))
     };
 
-    const after: boolean = get("renderContentAboveBackground");
     const under: boolean = get("renderTextAboveBackground");
 
-    const bodySel: string = under || !after ? `::before` : ` > div[role=application] > div.monaco-grid-view::after`;
+    const bodySel: string = under ? `::before` : ` > div[role=application] > div.monaco-grid-view::after`;
 
     return `(() => {` +
 // shared background css
@@ -105,7 +104,7 @@ bk_global.appendChild(document.createTextNode(\`
         width: 100%;
         height: 100%;
 
-        ${!after && !under ? `z-index: 1000;` : ''}
+        ${!under ? `z-index: 1000;` : ''}
 
         position: absolute;
 

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -104,8 +104,6 @@ bk_global.appendChild(document.createTextNode(\`
         width: 100%;
         height: 100%;
 
-        ${!under ? `z-index: 1000;` : ''}
-
         position: absolute;
 
         pointer-events: none;

--- a/src/extension/package.ts
+++ b/src/extension/package.ts
@@ -32,7 +32,6 @@ export type ConfigurationKey =
     "backgroundSizeValue" |
     "backgroundChangeTime" |
     "autoInstall" |
-    "renderContentAboveBackground" |
     "renderTextAboveBackground" |
     "useInvertedOpacity" |
     "settingScope" |

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -95,7 +95,7 @@ const moreMenu: (selected?: number) => void = (selected?: number) => {
         quickPickItem({
             label: "Render Text Above Background",
             description: descriptionBool("renderTextAboveBackground"),
-            detail: "Render text and code above the background; only supported for window backgrounds",
+            detail: "Show text, code, browser, and iframes on top of the background; only supported for window backgrounds",
             handle: handleBool("renderTextAboveBackground", i++)
         }),
         quickPickItem({

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -93,13 +93,7 @@ const moreMenu: (selected?: number) => void = (selected?: number) => {
             handle: handleBool("autoInstall", i++, true)
         }),
         quickPickItem({
-            label: "Render Content Above Background",
-            description: descriptionBool("renderContentAboveBackground"),
-            detail: "Render content like images, PDFs, and markdown previews above the background",
-            handle: handleBool("renderContentAboveBackground", i++)
-        }),
-        quickPickItem({
-            label: "$(beaker) Render Text Above Background",
+            label: "Render Text Above Background",
             description: descriptionBool("renderTextAboveBackground"),
             detail: "Render text and code above the background; only supported for window backgrounds",
             handle: handleBool("renderTextAboveBackground", i++)


### PR DESCRIPTION
* Remove `renderContentAboveBackground` option, after several VSCode updates this option is effectively non-functional.
* Move experimental `renderTextAboveBackground` to stable

#### Release Notes

This feature is no longer functional, instead use the **Render Text Above Background** option.