### PR TITLE
Remove automatic opacity migration for v3 opacity inversion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import { reload } from "./lib/vscode";
 import { api } from "./extension/api";
 import { install, uninstall } from "./extension/writer";
 import { optionMenu } from "./menu/menu";
-import { configuration, get, update } from "./extension/config";
+import { configuration } from "./extension/config";
 import { env } from "vscode";
 import { setUserDir } from "./extension/env";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,22 +140,6 @@ export const activate: (context: ExtensionContext) => any = (context: ExtensionC
 
     statusbar.show();
 
-    // migrate
-
-    if(!configuration().has("useInvertedOpacity")){
-        commands.executeCommand("workbench.action.reloadWindow"); // outdated manifest, force reload
-    }
-
-    if(context.globalState.get("migratedOpacity") !== true){ // if not yet migrated
-        if(get("backgroundOpacity", {scope: "global", includeDefault: false})){ // has opacity set
-            update("useInvertedOpacity", true, undefined, true) // update setting
-                .then(() => context.globalState.update("migratedOpacity", true)) // set migrated (changed)
-                .then(() => window.showInformationMessage("Background opacity settings have been migrated to the latest version."));
-        }else{
-            context.globalState.update("migratedOpacity", true); // set migrated (no change)
-        }
-    }
-
     // install
 
     if(configuration().get("autoInstall"))


### PR DESCRIPTION
Remove automatic migration as part of #379

#### Release Notes

This removes the automatic opacity migration from v2 to v3 (2024).

**Users using v3 or higher**

No action is needed; your opacity settings have already been converted as part of the v2 to v3 update.

**Users using v2**

Update to v3 to have your opacity settings migrated, then to v5. As a reminder, the **Use Inverted Opacity** setting can still be used to preserve the inverted opacity (v2) behavior.
