### PR TITLE
Fix sticky tree transparency when using render text over background option

### DIFF
--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -70,7 +70,7 @@ bk_global.appendChild(document.createTextNode(\`
     `body .split-view-view:nth-child(3) *:not(
         [role="tooltip"], .monaco-count-badge, .badge-content, .label, .action-item *, .monaco-button,
         .view-overlays *, .sticky-widget *, .monaco-tree-sticky-container *, .lines-content *, .suggest-widget, .suggest-widget *,
-        .monaco-list-row.focused, .monaco-list-row.selected, .monaco-list-row:hover),
+        .monaco-tree-sticky-container, .monaco-list-row.focused, .monaco-list-row.selected, .monaco-list-row:hover),
         body > div,
         .tabs-and-actions-container {
         background-color: unset !important;


### PR DESCRIPTION
current:

<img width="202" height="65" alt="image" src="https://github.com/user-attachments/assets/95957745-9f1d-4068-a1ea-c026b43fea6a" />

fixed version:

<img width="199" height="55" alt="image" src="https://github.com/user-attachments/assets/4fa258a7-db0b-4b9c-85a5-46f1821ee702" />
