### PR TITLE
Fix documentation popup transparency when using render text over background option

### DIFF
--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -69,7 +69,7 @@ bk_global.appendChild(document.createTextNode(\`
     ${!under ? "" :
     `body .split-view-view:nth-child(3) *:not(
         [role="tooltip"], .monaco-count-badge, .badge-content, .label, .action-item *, .monaco-button,
-        .view-overlays *, .sticky-widget *, .monaco-tree-sticky-container *, .lines-content *, .suggest-widget, .suggest-widget *, .suggest-details, .suggest-details *,
+        .view-overlays *, .sticky-widget *, .monaco-tree-sticky-container *, .lines-content *, .suggest-widget, .suggest-widget *, .suggest-details, .suggest-details *, .editor-widget, .editor-widget *,
         .monaco-list-row.focused, .monaco-list-row.selected, .monaco-list-row:hover),
         body > div,
         .tabs-and-actions-container {

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -69,10 +69,9 @@ bk_global.appendChild(document.createTextNode(\`
     ${!under ? "" :
     `body .split-view-view:nth-child(3) *:not(
         [role="tooltip"], .monaco-count-badge, .badge-content, .label, .action-item *, .monaco-button,
-        .view-overlays *, .sticky-widget *, .monaco-tree-sticky-container *, .lines-content *, .suggest-widget, .suggest-widget *, .suggest-details, .suggest-details *, .editor-widget, .editor-widget *,
-        .monaco-list-row.focused, .monaco-list-row.selected, .monaco-list-row:hover),
+        .view-overlays *, .sticky-widget *, .lines-content *, .suggest-widget, .suggest-widget *, .suggest-details, .suggest-details *, .editor-widget, .editor-widget *,
         .monaco-editor-overlaymessage, .monaco-editor-overlaymessage *, .context-view, .context-view *,
-        .monaco-tree-sticky-container, .monaco-list-row.focused, .monaco-list-row.selected, .monaco-list-row:hover),
+        .monaco-tree-sticky-container, .monaco-tree-sticky-container *, .monaco-list-row.focused, .monaco-list-row.selected, .monaco-list-row:hover),
         body > div,
         .tabs-and-actions-container {
         background-color: unset !important;

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -69,7 +69,7 @@ bk_global.appendChild(document.createTextNode(\`
     ${!under ? "" :
     `body .split-view-view:nth-child(3) *:not(
         [role="tooltip"], .monaco-count-badge, .badge-content, .label, .action-item *, .monaco-button,
-        .view-overlays *, .sticky-widget *, .monaco-tree-sticky-container *, .lines-content *, .suggest-widget, .suggest-widget *,
+        .view-overlays *, .sticky-widget *, .monaco-tree-sticky-container *, .lines-content *, .suggest-widget, .suggest-widget *, .suggest-details, .suggest-details *,
         .monaco-list-row.focused, .monaco-list-row.selected, .monaco-list-row:hover),
         body > div,
         .tabs-and-actions-container {

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -69,8 +69,8 @@ bk_global.appendChild(document.createTextNode(\`
     ${!under ? "" :
     `body .split-view-view:nth-child(3) *:not(
         [role="tooltip"], .monaco-count-badge, .badge-content, .label, .action-item *, .monaco-button,
-        .view-overlays *, .sticky-widget *, .lines-content *, .suggest-widget, .suggest-widget *, .suggest-details, .suggest-details *, .editor-widget, .editor-widget *,
         .monaco-editor-overlaymessage, .monaco-editor-overlaymessage *, .context-view, .context-view *,
+        .view-overlays *, .sticky-widget *, .lines-content *, .suggest-widget, .suggest-widget *, .suggest-details, .suggest-details *, .editor-widget, .editor-widget *,
         .monaco-tree-sticky-container, .monaco-tree-sticky-container *, .monaco-list-row.focused, .monaco-list-row.selected, .monaco-list-row:hover),
         body > div,
         .tabs-and-actions-container {


### PR DESCRIPTION
<img width="883" height="211" alt="image" src="https://github.com/user-attachments/assets/c0c7fab9-dff9-4193-bfc2-d67fbe1bd23e" />

<img width="442" height="131" alt="image" src="https://github.com/user-attachments/assets/bb3dc1b9-9d47-49ed-998a-9fb09ce136fb" />
