### PR TITLE
Fix tooltip/generate background when using render text over background option

### DIFF
--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -69,6 +69,7 @@ bk_global.appendChild(document.createTextNode(\`
     ${!under ? "" :
     `body .split-view-view:nth-child(3) *:not(
         [role="tooltip"], .monaco-count-badge, .badge-content, .label, .action-item *, .monaco-button,
+        .monaco-editor-overlaymessage, .monaco-editor-overlaymessage *, .context-view, .context-view *,
         .view-overlays *, .sticky-widget *, .monaco-tree-sticky-container *, .lines-content *, .suggest-widget, .suggest-widget *,
         .monaco-list-row.focused, .monaco-list-row.selected, .monaco-list-row:hover),
         body > div,


### PR DESCRIPTION
<img width="207" height="105" alt="image" src="https://github.com/user-attachments/assets/6ca4c3b8-7f19-4551-8ef8-93a86c90b6a4" />

<img width="214" height="90" alt="image" src="https://github.com/user-attachments/assets/c3567092-c631-48d5-8770-89e086961562" />

