### PR TITLE
Fix sudo not working on VS 1.123

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "code-background",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "code-background",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "license": "GPL-2.0-only",
             "devDependencies": {
                 "@types/node": "25.9.1",
@@ -22,7 +22,7 @@
                 "typescript": "6.0.3"
             },
             "engines": {
-                "vscode": "^1.121.0"
+                "vscode": "^1.123.0"
             }
         },
         "node_modules/@azu/format-text": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@types/node": "25.9.1",
                 "@types/tmp": "0.2.6",
                 "@types/vscode": "1.120.0",
-                "@vscode/sudo-prompt": "9.3.1",
+                "@vscode/sudo-prompt": "9.3.2",
                 "@vscode/test-electron": "2.5.2",
                 "@vscode/vsce": "3.9.1",
                 "esbuild": "0.28.0",
@@ -1083,9 +1083,9 @@
             }
         },
         "node_modules/@vscode/sudo-prompt": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/@vscode/sudo-prompt/-/sudo-prompt-9.3.1.tgz",
-            "integrity": "sha512-9ORTwwS74VaTn38tNbQhsA5U44zkJfcb0BdTSyyG6frP4e8KMtHuTXYmwefe5dpL8XB1aGSIVTaLjD3BbWb5iA==",
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@vscode/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
+            "integrity": "sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
         "theme": "dark"
     },
     "publisher": "Katsute",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "private": true,
     "engines": {
-        "vscode": "^1.121.0"
+        "vscode": "^1.123.0"
     },
     "categories": [
         "Other"

--- a/package.json
+++ b/package.json
@@ -357,7 +357,7 @@
         "@types/node": "25.9.1",
         "@types/tmp": "0.2.6",
         "@types/vscode": "1.120.0",
-        "@vscode/sudo-prompt": "9.3.1",
+        "@vscode/sudo-prompt": "9.3.2",
         "@vscode/test-electron": "2.5.2",
         "@vscode/vsce": "3.9.1",
         "esbuild": "0.28.0",


### PR DESCRIPTION
Broken in vs 316661

#### Release Notes

Fixes a Node compatibility issue with sudo caused by a bad VSCode release that did not declare a **breaking** Node version increase.