### PR TITLE
Fix reload not working on VSCode 1.123

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,13 +8,6 @@ body:
       value: |-
         Automatically prefill this bug report by opening an issue in the extension under **More Options** > **Report an issue** <br><br>
 
-  - type: markdown
-    attributes:
-      value: |-
-        **v6 Notice:**
-
-        This update introduced a breaking change to how backgrounds are installed, it is highly recommended to uninstall your background prior to update or run a reinstall of VSCode to clear out any old backgrounds.
-
   - type: checkboxes
     attributes:
       label: Checks

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,15 +8,6 @@ body:
       value: |-
         Automatically prefill this bug report by opening an issue in the extension under **More Options** > **Report an issue** <br><br>
 
-  - type: markdown
-    attributes:
-      value: |-
-        As of VSCode 1.123, Install, Uninstall, and Reload buttons do not refresh the background. This is a regression caused by the recent VSCode update.
-
-        For a temporary work around fully close and reopen VSCode to see background updates, window reloads no longer work.
-
-        Refer to [#600](https://github.com/KatsuteDev/Background/issues/600) for updates on this issue.
-
   - type: checkboxes
     attributes:
       label: Checks

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,6 +8,13 @@ body:
       value: |-
         Automatically prefill this bug report by opening an issue in the extension under **More Options** > **Report an issue** <br><br>
 
+  - type: markdown
+    attributes:
+      value: |-
+        **v6 Notice:**
+
+        This update introduced a breaking change to how backgrounds are installed, it is highly recommended to uninstall your background prior to update or run a reinstall of VSCode to clear out any old backgrounds.
+
   - type: checkboxes
     attributes:
       label: Checks

--- a/HELP.md
+++ b/HELP.md
@@ -6,7 +6,7 @@ This warning may appear after running the uninstall command, reopen VSCode for t
 
 #### VSCode stopped working
 
-This extension modifies an internal file to make backgrounds work, if VSCode stops working replace `%LocalAppData%\Programs\Microsoft VS Code\resources\app\out\vs\workbench\workbench.desktop.main.js` with `workbench.desktop.main-backup.js`.
+This extension modifies an internal file to make backgrounds work, if VSCode stops working replace `%LocalAppData%\Programs\Microsoft VS Code\resources\app\out\vs\code\electron-browser\workbench\workbench.html` with `workbench-backup.html`.
 
 This extension also modifies `%LocalAppData%\Programs\Microsoft VS Code\resources\app\product.json`, replace with `product-backup.json` if VSCode stops working.
 

--- a/HELP.md
+++ b/HELP.md
@@ -1,5 +1,22 @@
 ## Common Issues
 
+#### Legacy installation of Background has been detected
+
+This warning may appear when migrating to v6, there are two options to migrate:
+
+##### Rollback
+
+ 1. Right click the extension the extensions tab and choose **Install Specific Version...**
+ 2. Choose a version that is older than v6
+ 3. Click **Restart Extensions**
+ 4. Run the **Uninstall** command
+ 5. Fully close and reopen VSCode
+ 6. You can now update to v6 and use this extension
+
+##### Reinstall
+
+ 1. Reinstall [VSCode](https://code.visualstudio.com/download)
+
 #### Code installation is corrupt
 
 This warning may appear after running the uninstall command, reopen VSCode for this to disappear.

--- a/HELP.md
+++ b/HELP.md
@@ -1,7 +1,3 @@
-## v6 Notice
-
-This update introduces a breaking change to how backgrounds are installed, it is highly recommended to uninstall your background before updating to this version, or running a reinstall of VSCode to clear out any old backgrounds.
-
 ## Common Issues
 
 #### Code installation is corrupt

--- a/HELP.md
+++ b/HELP.md
@@ -1,3 +1,7 @@
+## v6 Notice
+
+This update introduces a breaking change to how backgrounds are installed, it is highly recommended to uninstall your background before updating to this version, or running a reinstall of VSCode to clear out any old backgrounds.
+
 ## Common Issues
 
 #### Code installation is corrupt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "code-background",
-    "version": "5.0.3",
+    "version": "6.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "code-background",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "license": "GPL-2.0-only",
             "devDependencies": {
                 "@types/node": "25.9.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "theme": "dark"
     },
     "publisher": "Katsute",
-    "version": "5.0.3",
+    "version": "6.0.0",
     "private": true,
     "engines": {
         "vscode": "^1.123.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,8 +63,8 @@ export const activate: (context: ExtensionContext) => any = (context: ExtensionC
 
     // internal files
     if(dir){
-        // %appdata%/Local/Programs/Microsoft VS Code/resources/app/out/vs/workbench/workbench.desktop.main.js
-        workbench = join(dir, "out", "vs", "workbench", "workbench.desktop.main.js");
+        // %appdata%/Local/Programs/Microsoft VS Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html
+        workbench = join(dir, "out", "vs", "code", "electron-browser", "workbench", "workbench.html");
         // %appdata%/Local/Programs/Microsoft VS Code/resources/app/product.json
         product = join(dir, "product.json");
 
@@ -75,7 +75,7 @@ export const activate: (context: ExtensionContext) => any = (context: ExtensionC
             window.showErrorMessage(`Failed to find '${product}', please report this issue`);
             return;
         }else{ // workbench & product exists
-            const workbench_backup: string = workbench.replace(".js", "-backup.js");
+            const workbench_backup: string = workbench.replace(".html", "-backup.html");
             const product_backup: string = product.replace(".json", "-backup.json");
 
             if(!existsSync(workbench_backup) || !existsSync(product_backup)){ // backup missing

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@
 import { join } from "path";
 import { platform, release } from "os";
 import { exec } from "@vscode/sudo-prompt";
-import { existsSync, copyFileSync } from "fs";
+import { existsSync, copyFileSync, readFileSync } from "fs";
 import { ConfigurationTarget, ExtensionContext, StatusBarAlignment, StatusBarItem, Uri, commands, window } from "vscode";
 
 import { copyCommand } from "./lib/file";
@@ -118,6 +118,15 @@ export const activate: (context: ExtensionContext) => any = (context: ExtensionC
         window.showErrorMessage("Failed to find application directory, please report this issue");
         return;
     }
+
+    // legacy warning
+    const legacyWorkbench: string = join(dir, "out", "vs", "workbench", "workbench.desktop.main.js");
+    if(existsSync(legacyWorkbench) && readFileSync(legacyWorkbench, "utf-8").includes("/* KatsuteDev/Background-start */"))
+        window.showErrorMessage("A legacy installation of Background has been detected, please rollback to an older version, uninstall backgrounds, then update to v6; or reinstall VSCode to clear out the old installation.", "Instructions", "Ignore")
+            .then((value?: string) => {
+                if(value === "Instructions")
+                    env.openExternal(Uri.parse("https://github.com/KatsuteDev/Background/blob/main/HELP.md#legacy-installation-of-background-has-been-detected"));
+            });
 
     // extension
 

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -24,9 +24,9 @@ import { resolve } from "../lib/glob";
 
 const identifier: string = "KatsuteDev/Background";
 
-const partition: RegExp = new RegExp(`^\\/\\* ${identifier}-start \\*\\/$` +
+const partition: RegExp = new RegExp(`^<!-- ${identifier}-start -->$` +
                                      `[\\s\\S]*?` +
-                                     `^\\/\\* ${identifier}-end \\*\\/$`, "gmi");
+                                     `^<!-- ${identifier}-end -->$`, "gmi");
 
 // extensions https://github.com/microsoft/vscode/blob/main/src/vs/platform/protocol/electron-main/protocolMainService.ts#L27
 
@@ -35,13 +35,15 @@ export const extensions: () => string[] = () => ["png", "jpg", "jpeg", "webp", "
 // inject
 
 export const inject: (content: string) => string = (content: string) =>
-    clean(content) + '\n' +
-    `/* ${identifier}-start */` + '\n' +
-    minifyJavaScript(getJavaScript()) + '\n' +
-    `/* ${identifier}-end */`;
+    clean(content).replace(/(<\/html>)/i,
+        `<!-- ${identifier}-start -->\n` +
+        `<script>${minifyJavaScript(getJavaScript())}</script>\n` +
+        `<!-- ${identifier}-end -->\n` +
+        `$1`
+    );
 
 export const clean: (content: string) => string = (s: string) =>
-    s.replace(partition, "").trim();
+    s.replace(partition, "");
 
 // javascript
 

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -42,8 +42,7 @@ export const inject: (content: string) => string = (content: string) =>
         `$1`
     );
 
-export const clean: (content: string) => string = (s: string) =>
-    s.replace(partition, "");
+export const clean: (content: string) => string = (s: string) => s.replace(partition, "");
 
 // javascript
 

--- a/src/extension/inject.ts
+++ b/src/extension/inject.ts
@@ -26,7 +26,7 @@ const identifier: string = "KatsuteDev/Background";
 
 const partition: RegExp = new RegExp(`^<!-- ${identifier}-start -->$` +
                                      `[\\s\\S]*?` +
-                                     `^<!-- ${identifier}-end -->$`, "gmi");
+                                     `^<!-- ${identifier}-end -->$\n?`, "gmi");
 
 // extensions https://github.com/microsoft/vscode/blob/main/src/vs/platform/protocol/electron-main/protocolMainService.ts#L27
 
@@ -42,7 +42,7 @@ export const inject: (content: string) => string = (content: string) =>
         `$1`
     );
 
-export const clean: (content: string) => string = (s: string) => s.replace(partition, "");
+export const clean: (content: string) => string = (s: string) => s.replace(partition, "").trim();
 
 // javascript
 

--- a/src/extension/writer.ts
+++ b/src/extension/writer.ts
@@ -39,17 +39,19 @@ export const uninstall: (workbench: PathLike, product: PathLike, force?: boolean
 
 // write
 
-const workbenchChecksum: RegExp = /(?<=^\s*"vs\/workbench\/workbench\.desktop\.main\.js\": \").*(?=\",\s*$)/gm;
+const workbenchChecksum: RegExp = /(?<=^\s*"vs\/code\/electron-browser\/workbench\/workbench\.html\": \").*(?=\",\s*$)/gm;
 
 const write: (workbench: PathLike, product: PathLike, content: string, force?: boolean) => void = (workbench: PathLike, product: PathLike, content: string, force: boolean = false) => {
-    const pJson: string = readFileSync(product, "utf-8").replace(workbenchChecksum, generateChecksum(content));
+    // allow inlined JS
+    const patched: string = content.replace(/\bscript-src\b(?![^'\n]*'unsafe-inline')/gm, "script-src 'unsafe-inline'");
+    const pJson: string = readFileSync(product, "utf-8").replace(workbenchChecksum, generateChecksum(patched));
 
     try{ // write changes
         setActive(true);
 
         let changed: boolean = force;
-        if(readFileSync(workbench, "utf-8") !== content){
-            writeFileSync(workbench, content, "utf-8");
+        if(readFileSync(workbench, "utf-8") !== patched){
+            writeFileSync(workbench, patched, "utf-8");
             changed = true;
         }
         if(readFileSync(product, "utf-8") !== pJson){
@@ -80,7 +82,7 @@ const write: (workbench: PathLike, product: PathLike, content: string, force?: b
                 if(value === "Yes"){
                     // use temp files
                     const workbenchTemp = fileSync().name;
-                    writeFileSync(workbenchTemp, content, "utf-8");
+                    writeFileSync(workbenchTemp, patched, "utf-8");
                     const productTemp = fileSync().name;
                     writeFileSync(productTemp, pJson, "utf-8");
 

--- a/src/lib/vscode.ts
+++ b/src/lib/vscode.ts
@@ -16,19 +16,13 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { env, InputBoxOptions, QuickPick, QuickPickItem, QuickPickItemKind, QuickPickOptions, Uri, window } from "vscode";
+import { commands, InputBoxOptions, QuickPick, QuickPickItem, QuickPickItemKind, QuickPickOptions, window } from "vscode";
 
 import { UI } from "../extension/config";
 
 // reload
 
-// export const reload: () => void = () => commands.executeCommand("workbench.action.reloadWindow");
-
-export const reload: () => void = () => window
-    .showWarningMessage("VSCode 1.123 has broken reload for this extension, as a temporary workaround please close and reopen the window to see the background update.", "View Issue", "Ignore")
-    .then((value?: string) =>
-        value === "View Issue" && env.openExternal(Uri.parse("https://github.com/KatsuteDev/Background/issues/600"))
-    );
+export const reload: () => void = () => commands.executeCommand("workbench.action.reloadWindow");
 
 // input
 


### PR DESCRIPTION
* Switch to alternative file for install
* Update checksum accordingly
* Revert notice for reload
* Remove legacy js

#### Release Notes

Some users may receive an error about a legacy installation, please refer to the following options to migrate to v6:

##### Rollback

 1. Right click the extension the extensions tab and choose **Install Specific Version...**
 2. Choose a version that is older than v6
 3. Click **Restart Extensions**
 4. Run the **Uninstall** command
 5. Fully close and reopen VSCode
 6. You can now update to v6 and use this extension

##### Reinstall

 1. Reinstall [VSCode](https://code.visualstudio.com/download)